### PR TITLE
Define d3d11 and dxgi return codes

### DIFF
--- a/libs/win32/d3d11.zig
+++ b/libs/win32/d3d11.zig
@@ -3,6 +3,7 @@ const IUnknown = windows.IUnknown;
 const UINT = windows.UINT;
 const WINAPI = windows.WINAPI;
 const GUID = windows.GUID;
+const HRESULT = windows.HRESULT;
 
 pub const CREATE_DEVICE_FLAG = UINT;
 pub const CREATE_DEVICE_SINGLETHREADED = 0x1;
@@ -278,3 +279,9 @@ pub const IID_IResource = GUID{
     .Data3 = 0x4952,
     .Data4 = .{ 0xb4, 0x7b, 0x5e, 0x45, 0x02, 0x6a, 0x86, 0x2d },
 };
+
+// Return codes as defined here: https://docs.microsoft.com/en-us/windows/win32/direct3d11/d3d11-graphics-reference-returnvalues
+pub const ERROR_FILE_NOT_FOUND = @bitCast(HRESULT, @as(c_ulong, 0x887C0002));
+pub const ERROR_TOO_MANY_UNIQUE_STATE_OBJECTS = @bitCast(HRESULT, @as(c_ulong, 0x887C0001));
+pub const ERROR_TOO_MANY_UNIQUE_VIEW_OBJECTS = @bitCast(HRESULT, @as(c_ulong, 0x887C0003));
+pub const ERROR_DEFERRED_CONTEXT_MAP_WITHOUT_INITIAL_DISCARD = @bitCast(HRESULT, @as(c_ulong, 0x887C0004));

--- a/libs/win32/dxgi.zig
+++ b/libs/win32/dxgi.zig
@@ -1593,3 +1593,29 @@ pub const IID_ISwapChain3 = GUID{
     .Data3 = 0x4ab0,
     .Data4 = .{ 0xb2, 0x36, 0x7d, 0xa0, 0x17, 0x0e, 0xda, 0xb1 },
 };
+
+// Return codes as defined here: https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-error
+pub const ERROR_ACCESS_DENIED = @bitCast(HRESULT, @as(c_ulong, 0x887A002B));
+pub const ERROR_ACCESS_LOST = @bitCast(HRESULT, @as(c_ulong, 0x887A0026));
+pub const ERROR_ALREADY_EXISTS = @bitCast(HRESULT, @as(c_ulong, 0x887A0036));
+pub const ERROR_CANNOT_PROTECT_CONTENT = @bitCast(HRESULT, @as(c_ulong, 0x887A002A));
+pub const ERROR_DEVICE_HUNG = @bitCast(HRESULT, @as(c_ulong, 0x887A0006));
+pub const ERROR_DEVICE_REMOVED = @bitCast(HRESULT, @as(c_ulong, 0x887A0005));
+pub const ERROR_DEVICE_RESET = @bitCast(HRESULT, @as(c_ulong, 0x887A0007));
+pub const ERROR_DRIVER_INTERNAL_ERROR = @bitCast(HRESULT, @as(c_ulong, 0x887A0020));
+pub const ERROR_FRAME_STATISTICS_DISJOINT = @bitCast(HRESULT, @as(c_ulong, 0x887A000B));
+pub const ERROR_GRAPHICS_VIDPN_SOURCE_IN_USE = @bitCast(HRESULT, @as(c_ulong, 0x887A000C));
+pub const ERROR_INVALID_CALL = @bitCast(HRESULT, @as(c_ulong, 0x887A0001));
+pub const ERROR_MORE_DATA = @bitCast(HRESULT, @as(c_ulong, 0x887A0003));
+pub const ERROR_NAME_ALREADY_EXISTS = @bitCast(HRESULT, @as(c_ulong, 0x887A002C));
+pub const ERROR_NONEXCLUSIVE = @bitCast(HRESULT, @as(c_ulong, 0x887A0021));
+pub const ERROR_NOT_CURRENTLY_AVAILABLE = @bitCast(HRESULT, @as(c_ulong, 0x887A0022));
+pub const ERROR_NOT_FOUND = @bitCast(HRESULT, @as(c_ulong, 0x887A0002));
+pub const ERROR_REMOTE_CLIENT_DISCONNECTED = @bitCast(HRESULT, @as(c_ulong, 0x887A0023));
+pub const ERROR_REMOTE_OUTOFMEMORY = @bitCast(HRESULT, @as(c_ulong, 0x887A0024));
+pub const ERROR_RESTRICT_TO_OUTPUT_STALE = @bitCast(HRESULT, @as(c_ulong, 0x887A0029));
+pub const ERROR_SDK_COMPONENT_MISSING = @bitCast(HRESULT, @as(c_ulong, 0x887A002D));
+pub const ERROR_SESSION_DISCONNECTED = @bitCast(HRESULT, @as(c_ulong, 0x887A0028));
+pub const ERROR_UNSUPPORTED = @bitCast(HRESULT, @as(c_ulong, 0x887A0004));
+pub const ERROR_WAIT_TIMEOUT = @bitCast(HRESULT, @as(c_ulong, 0x887A0027));
+pub const ERROR_WAS_STILL_DRAWING = @bitCast(HRESULT, @as(c_ulong, 0x887A000A));


### PR DESCRIPTION
As defined at here [here](https://docs.microsoft.com/en-us/windows/win32/direct3d11/d3d11-graphics-reference-returnvalues) and [here](https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-error) respectively.

I'm using these to turn HRESULTS into zig errors in a project that is only using the win32 lib from this repo. Also, it seems that the COM documentation defines a slightly different set of result codes than the above docs - hence I have left the return codes defined in misc.zig untouched.

On this topic, I'd like to move my error handling code into the win32 library. Would you be open to such changes? (it would be an alternative or potential eplacement to the error handling code in the common lib)