### PR TITLE
d3d11 bindings for vs and ps creation

### DIFF
--- a/libs/win32/d3d11.zig
+++ b/libs/win32/d3d11.zig
@@ -5,6 +5,7 @@ const WINAPI = windows.WINAPI;
 const GUID = windows.GUID;
 const HRESULT = windows.HRESULT;
 const HINSTANCE = windows.HINSTANCE;
+const SIZE_T = windows.SIZE_T;
 
 const d3dcommon = @import("d3dcommon.zig");
 const FEATURE_LEVEL = d3dcommon.FEATURE_LEVEL;
@@ -140,6 +141,32 @@ pub const IDeviceChild = extern struct {
             GetPrivateData: *anyopaque,
             SetPrivateData: *anyopaque,
             SetPrivateDataInterface: *anyopaque,
+        };
+    }
+};
+
+pub const IID_IClassLinkage = GUID.parse("{ddf57cba-9543-46e4-a12b-f207a0fe7fed}");
+pub const IClassLinkage = extern struct {
+    const Self = @This();
+    v: *const extern struct {
+        unknown: IUnknown.VTable(Self),
+        devchild: IDeviceChild.VTable(Self),
+        classlinkage: VTable(Self),
+    },
+    usingnamespace IUnknown.Methods(Self);
+    usingnamespace IDeviceChild.Methods(Self);
+    usingnamespace Methods(Self);
+
+    pub fn Methods(comptime T: type) type {
+        _ = T;
+        return extern struct {};
+    }
+
+    pub fn VTable(comptime T: type) type {
+        _ = T;
+        return extern struct {
+            GetClassInstance: *anyopaque,
+            CreateClassInstance: *anyopaque,
         };
     }
 };
@@ -325,6 +352,24 @@ pub const IDevice = extern struct {
             ) HRESULT {
                 return self.v.device.CreateRenderTargetView(self, pResource, pDesc, ppRTView);
             }
+            pub inline fn CreateVertexShader(
+                self: *T,
+                pShaderBytecode: *anyopaque,
+                BytecodeLength: SIZE_T,
+                pClassLinkage: ?*IClassLinkage,
+                ppVertexShader: ?*?*IVertexShader,
+            ) HRESULT {
+                return self.v.device.CreateVertexShader(self, pShaderBytecode, BytecodeLength, pClassLinkage, ppVertexShader);
+            }
+            pub inline fn CreatePixelShader(
+                self: *T,
+                pShaderBytecode: *anyopaque,
+                BytecodeLength: SIZE_T,
+                pClassLinkage: ?*IClassLinkage,
+                ppPixelShader: ?*?*IPixelShader,
+            ) HRESULT {
+                return self.v.device.CreatePixelShader(self, pShaderBytecode, BytecodeLength, pClassLinkage, ppPixelShader);
+            }
         };
     }
 
@@ -344,10 +389,22 @@ pub const IDevice = extern struct {
             ) callconv(WINAPI) HRESULT,
             CreateDepthStencilView: *anyopaque,
             CreateInputLayout: *anyopaque,
-            CreateVertexShader: *anyopaque,
+            CreateVertexShader: fn (
+                *T,
+                ?*anyopaque,
+                SIZE_T,
+                ?*IClassLinkage,
+                ?*?*IVertexShader,
+            ) callconv(WINAPI) HRESULT,
             CreateGeometryShader: *anyopaque,
             CreateGeometryShaderWithStreamOutput: *anyopaque,
-            CreatePixelShader: *anyopaque,
+            CreatePixelShader: fn (
+                *T,
+                ?*anyopaque,
+                SIZE_T,
+                ?*IClassLinkage,
+                ?*?*IPixelShader,
+            ) callconv(WINAPI) HRESULT,
             CreateHullShader: *anyopaque,
             CreateDomainShader: *anyopaque,
             CreateComputeShader: *anyopaque,
@@ -430,6 +487,52 @@ pub const IRenderTargetView = extern struct {
         return extern struct {
             GetDesc: *anyopaque,
         };
+    }
+};
+
+pub const IID_IVertexShader = GUID("{3b301d64-d678-4289-8897-22f8928b72f3}");
+pub const IVertexShader = extern struct {
+    const Self = @This();
+    v: *const extern struct {
+        unknown: IUnknown.VTable(Self),
+        devchild: IDeviceChild.VTable(Self),
+        vertexshader: VTable(Self),
+    },
+    usingnamespace IUnknown.Methods(Self);
+    usingnamespace IDeviceChild.VTable(Self);
+    usingnamespace Methods(Self);
+
+    fn Methods(comptime T: type) type {
+        _ = T;
+        return extern struct {};
+    }
+
+    fn VTable(comptime T: type) type {
+        _ = T;
+        return extern struct {};
+    }
+};
+
+pub const IID_IPixelShader = GUID("{ea82e40d-51dc-4f33-93d4-db7c9125ae8c}");
+pub const IPixelShader = extern struct {
+    const Self = @This();
+    v: *const extern struct {
+        unknown: IUnknown.VTable(Self),
+        devchild: IDeviceChild.VTable(Self),
+        pixelshader: VTable(Self),
+    },
+    usingnamespace IUnknown.Methods(Self);
+    usingnamespace IDeviceChild.VTable(Self);
+    usingnamespace Methods(Self);
+
+    fn Methods(comptime T: type) type {
+        _ = T;
+        return extern struct {};
+    }
+
+    fn VTable(comptime T: type) type {
+        _ = T;
+        return extern struct {};
     }
 };
 

--- a/libs/win32/d3dcommon.zig
+++ b/libs/win32/d3dcommon.zig
@@ -3,6 +3,8 @@ const IUnknown = windows.IUnknown;
 const UINT = windows.UINT;
 const WINAPI = windows.WINAPI;
 const SIZE_T = windows.SIZE_T;
+const LPCSTR = windows.LPCSTR;
+const GUID = windows.GUID;
 
 pub const PRIMITIVE_TOPOLOGY = enum(UINT) {
     UNDEFINED = 0,
@@ -72,6 +74,17 @@ pub const DRIVER_TYPE = enum(UINT) {
     WARP = 5,
 };
 
+pub const SHADER_MACRO = extern struct {
+    Name: LPCSTR,
+    Definition: LPCSTR,
+};
+
+pub const INCLUDE_TYPE = enum(UINT) {
+    INCLUDE_LOCAL = 0,
+    INCLUDE_SYSTEM = 1,
+};
+
+pub const IID_IBlob = GUID("{8BA5FB08-5195-40e2-AC58-0D989C3A0102}");
 pub const IBlob = extern struct {
     const Self = @This();
     v: *const extern struct {
@@ -96,6 +109,26 @@ pub const IBlob = extern struct {
         return extern struct {
             GetBufferPointer: fn (*T) callconv(WINAPI) *anyopaque,
             GetBufferSize: fn (*T) callconv(WINAPI) SIZE_T,
+        };
+    }
+};
+
+pub const IInclude = extern struct {
+    const Self = @This();
+    v: *const extern struct {
+        include: VTable(Self),
+    },
+    usingnamespace Methods(Self);
+
+    fn Methods(comptime T: type) type {
+        _ = T;
+        return extern struct {};
+    }
+
+    fn VTable(comptime T: type) type {
+        return extern struct {
+            Open: fn (*T, INCLUDE_TYPE, LPCSTR, *anyopaque, **anyopaque, *UINT) callconv(WINAPI) void,
+            Close: fn (*T, *anyopaque) callconv(WINAPI) void,
         };
     }
 };

--- a/libs/win32/d3dcompiler.zig
+++ b/libs/win32/d3dcompiler.zig
@@ -1,0 +1,53 @@
+//! Disclaimer: You should probably precompile your shaders with dxc and not use this!
+
+const std = @import("std");
+const windows = @import("windows.zig");
+const WINAPI = windows.WINAPI;
+const HRESULT = windows.HRESULT;
+const LPCSTR = windows.LPCSTR;
+const UINT = windows.UINT;
+const SIZE_T = windows.SIZE_T;
+
+const d3dcommon = @import("d3dcommon.zig");
+
+pub const COMPILE_FLAG = UINT;
+pub const COMPILE_DEBUG: COMPILE_FLAG = (1 << 0);
+pub const COMPILE_SKIP_VALIDATION: COMPILE_FLAG = (1 << 1);
+pub const COMPILE_SKIP_OPTIMIZATION: COMPILE_FLAG = (1 << 2);
+pub const COMPILE_PACK_MATRIX_ROW_MAJOR: COMPILE_FLAG = (1 << 3);
+pub const COMPILE_PACK_MATRIX_COLUMN_MAJOR: COMPILE_FLAG = (1 << 4);
+pub const COMPILE_PARTIAL_PRECISION: COMPILE_FLAG = (1 << 5);
+pub const COMPILE_FORCE_VS_SOFTWARE_NO_OPT: COMPILE_FLAG = (1 << 6);
+pub const COMPILE_FORCE_PS_SOFTWARE_NO_OPT: COMPILE_FLAG = (1 << 7);
+pub const COMPILE_NO_PRESHADER: COMPILE_FLAG = (1 << 8);
+pub const COMPILE_AVOID_FLOW_CONTROL: COMPILE_FLAG = (1 << 9);
+pub const COMPILE_PREFER_FLOW_CONTROL: COMPILE_FLAG = (1 << 10);
+pub const COMPILE_ENABLE_STRICTNESS: COMPILE_FLAG = (1 << 11);
+pub const COMPILE_ENABLE_BACKWARDS_COMPATIBILITY: COMPILE_FLAG = (1 << 12);
+pub const COMPILE_IEEE_STRICTNESS: COMPILE_FLAG = (1 << 13);
+pub const COMPILE_OPTIMIZATION_LEVEL0: COMPILE_FLAG = (1 << 14);
+pub const COMPILE_OPTIMIZATION_LEVEL1: COMPILE_FLAG = 0;
+pub const COMPILE_OPTIMIZATION_LEVEL2: COMPILE_FLAG = ((1 << 14) | (1 << 15));
+pub const COMPILE_OPTIMIZATION_LEVEL3: COMPILE_FLAG = (1 << 15);
+pub const COMPILE_RESERVED16: COMPILE_FLAG = (1 << 16);
+pub const COMPILE_RESERVED17: COMPILE_FLAG = (1 << 17);
+pub const COMPILE_WARNINGS_ARE_ERRORS: COMPILE_FLAG = (1 << 18);
+pub const COMPILE_RESOURCES_MAY_ALIAS: COMPILE_FLAG = (1 << 19);
+pub const COMPILE_ENABLE_UNBOUNDED_DESCRIPTOR_TABLES: COMPILE_FLAG = (1 << 20);
+pub const COMPILE_ALL_RESOURCES_BOUND: COMPILE_FLAG = (1 << 21);
+pub const COMPILE_DEBUG_NAME_FOR_SOURCE: COMPILE_FLAG = (1 << 22);
+pub const COMPILE_DEBUG_NAME_FOR_BINARY: COMPILE_FLAG = (1 << 23);
+
+pub extern "D3DCompiler_47" fn D3DCompile(
+    pSrcData: *const anyopaque,
+    SrcDataSize: SIZE_T,
+    pSourceName: ?LPCSTR,
+    pDefines: ?*const d3dcommon.SHADER_MACRO,
+    pInclude: ?*const d3dcommon.IInclude,
+    pEntrypoint: LPCSTR,
+    pTarget: LPCSTR,
+    Flags1: UINT,
+    Flags2: UINT,
+    ppCode: **d3dcommon.IBlob,
+    ppErrorMsgs: ?**d3dcommon.IBlob,
+) callconv(WINAPI) HRESULT;

--- a/libs/win32/win32.zig
+++ b/libs/win32/win32.zig
@@ -15,6 +15,9 @@ pub const xaudio2 = @import("xaudio2.zig");
 pub const xaudio2fx = @import("xaudio2fx.zig");
 pub const xapo = @import("xapo.zig");
 
+/// Disclaimer: You should probably precompile your shaders with dxc and not use d3dcompiler!
+pub const d3dcompiler = @import("d3dcompiler.zig");
+
 const HRESULT = base.HRESULT;
 const S_OK = base.S_OK;
 


### PR DESCRIPTION
Adds the nessesary bindings to create pixel and vertex shaders on d3d11.

Also adds naughty bindings for d3dcompiler