### PR TITLE
fix build errors for zig 0.10.0-dev.2023+032c722d2

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -126,7 +126,7 @@ fn ensureSubmodules(allocator: std.mem.Allocator) !void {
     if (std.process.getEnvVarOwned(allocator, "NO_ENSURE_SUBMODULES")) |no_ensure_submodules| {
         if (std.mem.eql(u8, no_ensure_submodules, "true")) return;
     } else |_| {}
-    const child = try std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", "--recursive" }, allocator);
+    var child = std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", "--recursive" }, allocator);
     child.cwd = thisDir();
     child.stderr = std.io.getStdErr();
     child.stdout = std.io.getStdOut();

--- a/libs/mach-glfw/system_sdk.zig
+++ b/libs/mach-glfw/system_sdk.zig
@@ -234,7 +234,7 @@ fn determineSdkRoot(allocator: std.mem.Allocator, org: []const u8, name: []const
 }
 
 fn exec(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []const u8) !void {
-    const child = try std.ChildProcess.init(argv, allocator);
+    var child = std.ChildProcess.init(argv, allocator);
     child.cwd = cwd;
     _ = try child.spawnAndWait();
 }

--- a/libs/mach-gpu-dawn/build.zig
+++ b/libs/mach-gpu-dawn/build.zig
@@ -180,7 +180,7 @@ fn ensureSubmodules(allocator: std.mem.Allocator) !void {
     if (std.process.getEnvVarOwned(allocator, "NO_ENSURE_SUBMODULES")) |no_ensure_submodules| {
         if (std.mem.eql(u8, no_ensure_submodules, "true")) return;
     } else |_| {}
-    const child = try std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", "--recursive" }, allocator);
+    var child = std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", "--recursive" }, allocator);
     child.cwd = thisDir();
     child.stderr = std.io.getStdErr();
     child.stdout = std.io.getStdOut();
@@ -442,7 +442,7 @@ fn gitClone(allocator: std.mem.Allocator, repository: []const u8, dir: []const u
 
 fn downloadFile(allocator: std.mem.Allocator, target_file: []const u8, url: []const u8) !void {
     std.debug.print("downloading {s}..\n", .{url});
-    const child = try std.ChildProcess.init(&.{ "curl", "-L", "-o", target_file, url }, allocator);
+    var child = std.ChildProcess.init(&.{ "curl", "-L", "-o", target_file, url }, allocator);
     child.cwd = thisDir();
     child.stderr = std.io.getStdErr();
     child.stdout = std.io.getStdOut();

--- a/libs/zmath/src/zmath.zig
+++ b/libs/zmath/src/zmath.zig
@@ -3439,7 +3439,7 @@ test "zmath.acos32" {
 
 pub fn modAngle32(in_angle: f32) f32 {
     const angle = in_angle + math.pi;
-    var temp: f32 = math.fabs(angle);
+    var temp: f32 = @fabs(angle);
     temp = temp - (2.0 * math.pi * @intToFloat(f32, @floatToInt(i32, temp / math.pi)));
     temp = temp - math.pi;
     if (angle < 0.0) {


### PR DESCRIPTION
I just installed zig on my M1 MacBook Pro, using homebrew, `brew install zig --HEAD`, and ended up with `zig version 0.10.0-dev.2023+032c722d2`, which reported a few minor compile errors when running `zig build` in the repository root.

- Apparently `std.ChildProcess.init()` no longer returns an error, so the `try` keyword is no longer relevant, but the error message was somewhat confusing to a newb like myself:
```
./build.zig:129:44: error: expected error union type, found 'std.child_process.ChildProcess'
    const child = try std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", "--recursive" }, allocator);
                                           ^
```

- When the child process is declared `const child`, the next line, `child.cwd = thisDir();` becomes an error:
```
./build.zig:130:24: error: cannot assign to constant
    child.cwd = thisDir();
                       ^
```

- It seems `math.fabs()` has been replaced by the `@fabs()` builtin:
```
./libs/zmath/src/zmath.zig:3442:25: error: container 'std.math' has no member called 'fabs'
    var temp: f32 = math.fabs(angle);
                        ^
```

After fixing these, I was able to successfully build the root of the repo.  I'm not yet able to build `samples/triangle_wgpu` due to the following error:
```
./build.zig:6:17: error: import of file outside package path: '../../build.zig'
const Options = @import("../../build.zig").Options;
                ^
```

If I figure out how to fix that, I will create another PR.