### PR TITLE
Added fibers support to ztracy

### DIFF
--- a/libs/zd3d12/README.md
+++ b/libs/zd3d12/README.md
@@ -52,7 +52,7 @@ pub fn build(b: *std.build.Builder) void {
     exe.addPackage(zd3d12.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(tracy, enable_tracy);
+    ztracy.link(tracy, enable_tracy, .{});
     zd3d12.link(exe);
 }
 ```

--- a/libs/ztracy/README.md
+++ b/libs/ztracy/README.md
@@ -23,7 +23,7 @@ pub fn build(b: *std.build.Builder) void {
     const options_pkg = exe_options.getPackage("build_options");
     exe.addPackage(ztracy.getPkg(b, options_pkg));
 
-    ztracy.link(exe, enable_tracy);
+    ztracy.link(exe, enable_tracy, .{});
 }
 ```
 
@@ -41,4 +41,15 @@ pub fn main() !void {
         ...
     }
 }
+```
+
+## Async "Fibers" support
+
+Tracy v0.8.0 added support for marking fibers (also called green threads,
+coroutines, and other forms of cooperative multitasking). This support requires
+an additional option passed through when compiling the Tracy library, so change
+the `link()` call in your `build.zig` to:
+
+```zig
+    ztracy.link(exe, enable_tracy, .{ .fibers = true });
 ```

--- a/libs/ztracy/build.zig
+++ b/libs/ztracy/build.zig
@@ -9,11 +9,22 @@ pub fn getPkg(b: *std.build.Builder, options_pkg: std.build.Pkg) std.build.Pkg {
     return b.dupePkg(pkg);
 }
 
-pub fn link(exe: *std.build.LibExeObjStep, enable_tracy: bool) void {
+pub const TracyBuildOptions = struct {
+    fibers: bool = false,
+};
+
+pub fn link(
+    exe: *std.build.LibExeObjStep,
+    enable_tracy: bool,
+    build_opts: TracyBuildOptions,
+) void {
     if (enable_tracy) {
+        const fibers_flag = if (build_opts.fibers) "-DTRACY_FIBERS" else "";
+
         exe.addIncludeDir(thisDir() ++ "/libs/tracy");
         exe.addCSourceFile(thisDir() ++ "/libs/tracy/TracyClient.cpp", &.{
             "-DTRACY_ENABLE",
+            fibers_flag,
             // MinGW doesn't have all the newfangled windows features,
             // so we need to pretend to have an older windows version.
             "-D_WIN32_WINNT=0x601",

--- a/libs/ztracy/src/ztracy.zig
+++ b/libs/ztracy/src/ztracy.zig
@@ -227,6 +227,11 @@ const tracy_stub = struct {
         _ = flip;
     }
 
+    pub inline fn FiberEnter(name: [*:0]const u8) void {
+        _ = name;
+    }
+    pub inline fn FiberLeave() void {}
+
     pub inline fn PlotF(name: [*:0]const u8, val: f64) void {
         _ = name;
         _ = val;
@@ -512,6 +517,13 @@ const tracy_full = struct {
     }
     pub inline fn FrameImage(image: ?*const anyopaque, width: u16, height: u16, offset: u8, flip: c_int) void {
         c.___tracy_emit_frame_image(image, width, height, offset, flip);
+    }
+
+    pub inline fn FiberEnter(name: [*:0]const u8) void {
+        c.___tracy_fiber_enter(name);
+    }
+    pub inline fn FiberLeave() void {
+        c.___tracy_fiber_leave();
     }
 
     pub inline fn PlotF(name: [*:0]const u8, val: f64) void {

--- a/samples/audio_experiments/build.zig
+++ b/samples/audio_experiments/build.zig
@@ -45,7 +45,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(zwin32.pkg);
     exe.addPackage(zmath.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zxaudio2.link(exe, options.enable_dx_debug);
     common.link(exe);

--- a/samples/audio_playback_test/build.zig
+++ b/samples/audio_playback_test/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 

--- a/samples/bindless/build.zig
+++ b/samples/bindless/build.zig
@@ -44,7 +44,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(zwin32.pkg);
     exe.addPackage(zmesh.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zmesh.link(exe);
     common.link(exe);

--- a/samples/bullet_physics_test/build.zig
+++ b/samples/bullet_physics_test/build.zig
@@ -46,7 +46,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(zwin32.pkg);
     exe.addPackage(zbullet.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zbullet.link(exe);
     zmesh.link(exe);

--- a/samples/directml_convolution_test/build.zig
+++ b/samples/directml_convolution_test/build.zig
@@ -67,7 +67,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 

--- a/samples/intro/build.zig
+++ b/samples/intro/build.zig
@@ -58,7 +58,7 @@ pub fn build(b: *std.build.Builder, options: Options, comptime intro_index: u32)
     exe.addPackage(znoise.pkg);
     exe.addPackage(zbullet.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zmesh.link(exe);
     znoise.link(exe);

--- a/samples/mesh_shader_test/build.zig
+++ b/samples/mesh_shader_test/build.zig
@@ -44,7 +44,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(zwin32.pkg);
     exe.addPackage(zmesh.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zmesh.link(exe);
     common.link(exe);

--- a/samples/minimal/build.zig
+++ b/samples/minimal/build.zig
@@ -30,7 +30,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 

--- a/samples/physically_based_rendering/build.zig
+++ b/samples/physically_based_rendering/build.zig
@@ -47,7 +47,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(zmesh.pkg);
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zmesh.link(exe);
     common.link(exe);

--- a/samples/procedural_mesh/build.zig
+++ b/samples/procedural_mesh/build.zig
@@ -48,7 +48,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(zmesh.pkg);
     exe.addPackage(znoise.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zmesh.link(exe);
     znoise.link(exe);

--- a/samples/rasterization/build.zig
+++ b/samples/rasterization/build.zig
@@ -46,7 +46,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(zmesh.pkg);
     exe.addPackage(zmath.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     zmesh.link(exe);
     common.link(exe);

--- a/samples/simple3d/build.zig
+++ b/samples/simple3d/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 

--- a/samples/simple_raytracer/build.zig
+++ b/samples/simple_raytracer/build.zig
@@ -44,7 +44,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 

--- a/samples/textured_quad/build.zig
+++ b/samples/textured_quad/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 

--- a/samples/triangle/build.zig
+++ b/samples/triangle/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 

--- a/samples/vector_graphics_test/build.zig
+++ b/samples/vector_graphics_test/build.zig
@@ -31,7 +31,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     exe.addPackage(common.getPkg(b, options_pkg));
     exe.addPackage(zwin32.pkg);
 
-    ztracy.link(exe, options.enable_tracy);
+    ztracy.link(exe, options.enable_tracy, .{});
     zd3d12.link(exe);
     common.link(exe);
 


### PR DESCRIPTION
Hello Michal - this PR adds support for the Fiber annotations added to Tracy v0.8.0 and above. The actual runtime code is straightforward, but it requires an additional compilation flag (`-DTRACY_FIBERS`) is passed through, so I've added an options struct to the build step. 

According to the Tracy docs this has some small overhead, so I've left it off by default.

With this patch, an async event loop can now mark zones that span suspend points, and Tracy will keep the necessary context to show what the async task (aka fiber / coroutine / green-thread) was doing as though it was a single logical flow of control.