### PR TITLE
zgpu: Fix warning for Git LFS

### DIFF
--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -1225,7 +1225,7 @@ pub fn checkContent(comptime content_dir: []const u8) !void {
             \\Please install Git LFS (Large File Support) and run (in the repo):
             \\
             \\git lfs install
-            \\git pull
+            \\git lfs pull
             \\
             \\For more info please see: https://git-lfs.github.com/
             \\


### PR DESCRIPTION
This fixes a slight instruction mistake when downloading the Git LFS files after the initial `git clone`.

(Nice work on the libraries by the way, it looks neat)