### PR TITLE
WIP Attempt to use zpool in zgpu

### DIFF
--- a/libs/zgpu/build.zig
+++ b/libs/zgpu/build.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const glfw = @import("../mach-glfw/build.zig");
 const gpu_dawn = @import("../mach-gpu-dawn/build.zig");
+const zpool = @import("../zpool/build.zig");
 
 pub const Options = struct {
     glfw_options: glfw.Options = .{},
@@ -17,6 +18,7 @@ fn buildLibrary(
     lib.setTarget(exe.target);
     glfw.link(exe.builder, lib, options.glfw_options);
     gpu_dawn.link(exe.builder, lib, options.gpu_dawn_options);
+    zpool.link(lib);
 
     // If you don't want to use 'dear imgui' library just comment out below lines and do not use `zgpu.gui`
     // namespace in your code.
@@ -33,6 +35,7 @@ fn buildLibrary(
     // If you don't want to use 'stb_image' library just comment out below line and do not use `zgpu.stbi`
     // namespace in your code.
     lib.addCSourceFile(thisDir() ++ "/libs/stb/stb_image.c", &.{"-std=c99"});
+    lib.addPackage(zpool.pkg);
 
     return lib;
 }
@@ -40,6 +43,7 @@ fn buildLibrary(
 pub fn link(exe: *std.build.LibExeObjStep, options: Options) void {
     glfw.link(exe.builder, exe, options.glfw_options);
     gpu_dawn.link(exe.builder, exe, options.gpu_dawn_options);
+    zpool.link(exe);
 
     const lib = buildLibrary(exe, options);
     exe.linkLibrary(lib);
@@ -51,7 +55,7 @@ pub fn link(exe: *std.build.LibExeObjStep, options: Options) void {
 pub const pkg = std.build.Pkg{
     .name = "zgpu",
     .path = .{ .path = thisDir() ++ "/src/zgpu.zig" },
-    .dependencies = &.{glfw.pkg},
+    .dependencies = &.{glfw.pkg, zpool.pkg},
 };
 
 fn thisDir() []const u8 {

--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -1716,3 +1716,9 @@ pub const bglBuffer = gpu.BindGroupLayout.Entry.buffer;
 pub const bglTexture = gpu.BindGroupLayout.Entry.texture;
 pub const bglSampler = gpu.BindGroupLayout.Entry.sampler;
 pub const bglStorageTexture = gpu.BindGroupLayout.Entry.storageTexture;
+
+test "use zpool package from zgpu?" {
+    const zpool = @import("zpool");
+    const VoidPool = zpool.Pool(16, 16, void, struct {});
+    std.debug.print("\n@sizeOf(VoidPool): {}\n", .{ @sizeOf(VoidPool)});
+}

--- a/libs/zpool/build.zig
+++ b/libs/zpool/build.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 
-const main = .{ .zig = thisDir() ++ "/src/main.zig" };
-
 pub const pkg = std.build.Pkg{
     .name = "zpool",
-    .path = .{ .path = main.zig },
+    .path = .{ .path = thisDir() ++ "/src/main.zig" },
 };
 
 pub fn build(b: *std.build.Builder) void {
@@ -21,7 +19,7 @@ pub fn buildTests(
     build_mode: std.builtin.Mode,
     target: std.zig.CrossTarget,
 ) *std.build.LibExeObjStep {
-    const tests = b.addTest(main.zig);
+    const tests = b.addTest(thisDir() ++ "/src/main.zig");
     tests.setBuildMode(build_mode);
     tests.setTarget(target);
     link(tests);
@@ -29,7 +27,7 @@ pub fn buildTests(
 }
 
 fn buildLibrary(exe: *std.build.LibExeObjStep) *std.build.LibExeObjStep {
-    const lib = exe.builder.addStaticLibrary("zpool", main.zig);
+    const lib = exe.builder.addStaticLibrary("zpool", thisDir() ++ "/src/main.zig");
     lib.setBuildMode(exe.build_mode);
     lib.setTarget(exe.target);
     return lib;


### PR DESCRIPTION
Hello Michal.  I'm having trouble figuring out how to add a dependency from `zgpu` -> `zpool`, so that I can replace `zgpu`'s `ResourcePool` with `zpool.Pool`.  
This PR shows what I've tried so far.  I added a test to the end of zgpu.zig where I'm trying to import zpool, but when I run `zig test 
libs/zgpu/src/zgpu.zig`, I get the following error message:

```sh
$ zig test libs/zgpu/src/zgpu.zig 
./libs/zgpu/src/zgpu.zig:1721:19: error: unable to find 'zpool'
    const zpool = @import("zpool");
                  ^
```

Any advice you can offer would be greatly appreciated.  Thanks in advance!
