### PR TITLE
zpool v0.2

### DIFF
--- a/libs/zpool/src/embedded_ring_queue.zig
+++ b/libs/zpool/src/embedded_ring_queue.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+
+pub fn EmbeddedRingQueue(comptime TElement: type) type {
+    const assert = std.debug.assert;
+
+    return struct {
+        const Self = @This();
+
+        pub const Error = error{
+            Empty,
+            Full,
+        };
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        pub const Element = TElement;
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        head: usize = 0,
+        tail: usize = 0,
+        storage: []Element = &.{},
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        pub fn init(buffer: []Element) Self {
+            return .{ .storage = buffer };
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        pub fn capacity(self: Self) usize {
+            return self.storage.len;
+        }
+
+        pub fn len(self: Self) usize {
+            return self.tail -% self.head;
+        }
+
+        pub fn empty(self: Self) bool {
+            return self.len() == 0;
+        }
+
+        pub fn full(self: Self) bool {
+            return self.len() == self.capacity();
+        }
+
+        pub fn clear(self: *Self) void {
+            self.head = 0;
+            self.tail = 0;
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        pub fn didEnqueue(self: *Self, value: Element) bool {
+            if (!self.full()) {
+                self.enqueueUnchecked(value);
+                return true;
+            }
+            return false;
+        }
+
+        pub fn didDequeue(self: *Self, value: *Element) bool {
+            if (!self.empty()) {
+                self.dequeueUnchecked(value);
+                return true;
+            }
+            return false;
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        pub fn enqueue(self: *Self, value: Element) Error!void {
+            if (self.didEnqueue(value)) {
+                return;
+            }
+            return Error.Full;
+        }
+
+        pub fn dequeue(self: *Self) Error!Element {
+            var value: Element = undefined;
+            if (self.didDequeue(&value)) {
+                return value;
+            }
+            return Error.Empty;
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        pub fn enqueueAssumeNotFull(self: *Self, value: Element) void {
+            assert(!self.full());
+            self.enqueueUnchecked(value);
+        }
+
+        pub fn dequeueAssumeNotEmpty(self: *Self) Element {
+            assert(!self.empty());
+            var value: Element = undefined;
+            self.dequeueUnchecked(&value);
+            return value;
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        pub fn enqueueUnchecked(self: *Self, value: Element) void {
+            const tail_index = self.tail % self.storage.len;
+            self.storage[tail_index] = value;
+            self.tail +%= 1;
+        }
+
+        pub fn dequeueUnchecked(self: *Self, value: *Element) void {
+            const head_index = self.head % self.storage.len;
+            value.* = self.storage[head_index];
+            self.head +%= 1;
+        }
+    };
+}
+
+//------------------------------------------------------------------------------
+
+const expectEqual = std.testing.expectEqual;
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+test "EmbeddedRingQueue basics" {
+    var buffer: [16]usize = undefined;
+    var queue = EmbeddedRingQueue(usize).init(buffer[0..]);
+
+    try expectEqual(buffer.len, queue.capacity());
+    try expectEqual(@as(usize, 0), queue.len());
+    try expectEqual(true, queue.empty());
+    try expectEqual(false, queue.full());
+
+    for (buffer) |_, i| {
+        try expectEqual(i, queue.len());
+        try queue.enqueue(i);
+        try expectEqual(i, buffer[i]);
+    }
+
+    try expectEqual(buffer.len, queue.capacity());
+    try expectEqual(buffer.len, queue.len());
+    try expectEqual(false, queue.empty());
+    try expectEqual(true, queue.full());
+
+    for (buffer) |_, i| {
+        try expectEqual(buffer.len - i, queue.len());
+        const j = try queue.dequeue();
+        try expectEqual(i, j);
+    }
+
+    try expectEqual(buffer.len, queue.capacity());
+    try expectEqual(@as(usize, 0), queue.len());
+    try expectEqual(true, queue.empty());
+    try expectEqual(false, queue.full());
+
+    for (buffer) |_, i| {
+        try expectEqual(i, queue.len());
+        try queue.enqueue(i);
+        try expectEqual(i, buffer[i]);
+    }
+
+    try expectEqual(buffer.len, queue.capacity());
+    try expectEqual(buffer.len, queue.len());
+    try expectEqual(false, queue.empty());
+    try expectEqual(true, queue.full());
+
+    queue.clear();
+
+    try expectEqual(buffer.len, queue.capacity());
+    try expectEqual(@as(usize, 0), queue.len());
+    try expectEqual(true, queue.empty());
+    try expectEqual(false, queue.full());
+}
+
+//------------------------------------------------------------------------------

--- a/libs/zpool/src/handle.zig
+++ b/libs/zpool/src/handle.zig
@@ -49,8 +49,8 @@ pub fn Handle(
     if (index_bits == 0) @compileError("index_bits must be greater than 0");
     if (cycle_bits == 0) @compileError("cycle_bits must be greater than 0");
 
-    const value_bits: u16 = @as(u16, index_bits) + @as(u16, cycle_bits);
-    const Value = switch (value_bits) {
+    const id_bits: u16 = @as(u16, index_bits) + @as(u16, cycle_bits);
+    const Id = switch (id_bits) {
         8 => u8,
         16 => u16,
         32 => u32,
@@ -77,10 +77,12 @@ pub fn Handle(
 
         pub const max_index = ~@as(Index, 0);
         pub const max_cycle = ~@as(Cycle, 0);
-        pub const max_count = @as(Value, max_index - 1) + 2;
+        pub const max_count = @as(Id, max_index - 1) + 2;
 
-        value: Value,
+        id: Id,
         compact: packed struct { index: Index, cycle: Cycle },
+
+        pub const zero = Self{ .id = 0 };
 
         pub fn init(_index: Index, _cycle: Cycle) Self {
             return .{ .compact = .{ .index = _index, .cycle = _cycle } };
@@ -88,8 +90,8 @@ pub fn Handle(
 
         pub fn addressable(self: Self) AddressableHandle {
             return .{
-                .index = self.compact.index,
-                .cycle = self.compact.cycle,
+                .index = self.index(),
+                .cycle = self.cycle(),
             };
         }
 
@@ -102,11 +104,12 @@ pub fn Handle(
         }
 
         pub fn eql(a: Self, b: Self) bool {
-            return a.value == b.value;
+            return a.id == b.id;
         }
 
         pub const AddressableHandle = struct {
-            const Compact = Self;
+            pub const Compact = Self;
+
             index: AddressableIndex = 0,
             cycle: AddressableCycle = 0,
 

--- a/libs/zpool/src/main.zig
+++ b/libs/zpool/src/main.zig
@@ -1,10 +1,7 @@
-// zpool v0.1
+// zpool v0.2
 
-pub const handles = @import("handles.zig");
-pub const pools = @import("pools.zig");
-
-pub const Handle = handles.Handle;
-pub const Pool = pools.Pool;
+pub const Handle = @import("handle.zig").Handle;
+pub const Pool = @import("pool.zig").Pool;
 
 // ensure transitive closure of test coverage
 comptime {


### PR DESCRIPTION
Pool() now stores free indices in a queue, and recycles released handles in FIFO order.
Pool.add() now first attempts to issue an unused index within capacity,
then attempts to reuse an index from the free queue,
and failing that will attempt to increase capacity in order to issue a new index.
