### PR TITLE
JoltC: Remaining Body bindings

### DIFF
--- a/libs/zjolt/libs/JoltC/JoltC.cpp
+++ b/libs/zjolt/libs/JoltC/JoltC.cpp
@@ -1894,7 +1894,7 @@ JPH_MotionProperties_AddAngularVelocityStep(
 }
 //--------------------------------------------------------------------------------------------------
 JPH_CAPI void
-JPH_MotionProperties_SubAngularangularStep(
+JPH_MotionProperties_SubAngularVelocityStep(
     JPH_MotionProperties *in_properties,
     const float in_angular_velocity_change[3]
 )

--- a/libs/zjolt/libs/JoltC/JoltC.cpp
+++ b/libs/zjolt/libs/JoltC/JoltC.cpp
@@ -1421,12 +1421,12 @@ JPH_Body_GetInverseCenterOfMassTransform(const JPH_Body *in_body, float out_tran
     m.StoreFloat4x4(reinterpret_cast<JPH::Float4 *>(out_transform));
 }
 //--------------------------------------------------------------------------------------------------
-JPH_CAPI JPH_AABox
+JPH_CAPI const JPH_AABox *
 JPH_Body_GetWorldSpaceBounds(const JPH_Body *in_body)
 {
     assert(in_body != nullptr);
-    return static_cast<JPH_AABox>(
-        reinterpret_cast<const JPH::Body *>(in_body)->GetWorldSpaceBounds()
+    return reinterpret_cast<const JPH_AABox *>(
+        &reinterpret_cast<const JPH::Body *>(in_body)->GetWorldSpaceBounds()
     );
 }
 //--------------------------------------------------------------------------------------------------
@@ -1481,9 +1481,8 @@ JPH_Body_GetTransformedShape(const JPH_Body *in_body)
 {
     assert(in_body != nullptr);
     const auto body = reinterpret_cast<const JPH::Body *>(in_body);
-    return static_cast<JPH_TransformedShape>(
-        reinterpret_cast<const JPH::Body *>(in_body)->GetTransformedShape()
-    );
+    const JPH::TransformedShape transformed_shape = body->GetTransformedShape();
+    return *reinterpret_cast<const JPH_TransformedShape *>(&transformed_shape);
 }
 //--------------------------------------------------------------------------------------------------
 JPH_CAPI JPH_BodyCreationSettings
@@ -1491,9 +1490,8 @@ JPH_Body_GetBodyCreationSettings(const JPH_Body *in_body)
 {
     assert(in_body != nullptr);
     const auto body = reinterpret_cast<const JPH::Body *>(in_body);
-    return static_cast<JPH_BodyCreationSettings>(
-        reinterpret_cast<const JPH::Body *>(in_body)->GetBodyCreationSettings()
-    );
+    const JPH::BodyCreationSettings settings = body->GetBodyCreationSettings();
+    return *reinterpret_cast<const JPH_BodyCreationSettings *>(&settings);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/libs/zjolt/libs/JoltC/JoltC.cpp
+++ b/libs/zjolt/libs/JoltC/JoltC.cpp
@@ -42,6 +42,7 @@ AssertFailedImpl(const char *in_expression,
 //--------------------------------------------------------------------------------------------------
 static_assert(sizeof(JPH::BodyID)                  == sizeof(JPH_BodyID));
 static_assert(sizeof(JPH::SubShapeID)              == sizeof(JPH_SubShapeID));
+static_assert(sizeof(JPH::SubShapeIDCreator)       == sizeof(JPH_SubShapeIDCreator));
 static_assert(sizeof(JPH::EShapeType)              == sizeof(JPH_ShapeType));
 static_assert(sizeof(JPH::EShapeSubType)           == sizeof(JPH_ShapeSubType));
 static_assert(sizeof(JPH::EMotionType)             == sizeof(JPH_MotionType));
@@ -64,6 +65,7 @@ static_assert(sizeof(JPH::ContactManifold)         == sizeof(JPH_ContactManifold
 static_assert(sizeof(JPH::ContactSettings)         == sizeof(JPH_ContactSettings));
 static_assert(sizeof(JPH::SubShapeIDPair)          == sizeof(JPH_SubShapeIDPair));
 static_assert(sizeof(JPH::CollideShapeResult)      == sizeof(JPH_CollideShapeResult));
+static_assert(sizeof(JPH::TransformedShape)        == sizeof(JPH_TransformedShape));
 
 static_assert(alignof(JPH::AABox)                  == alignof(JPH_AABox));
 static_assert(alignof(JPH::Plane)                  == alignof(JPH_Plane));
@@ -77,6 +79,7 @@ static_assert(alignof(JPH::ContactManifold)        == alignof(JPH_ContactManifol
 static_assert(alignof(JPH::ContactSettings)        == alignof(JPH_ContactSettings));
 static_assert(alignof(JPH::SubShapeIDPair)         == alignof(JPH_SubShapeIDPair));
 static_assert(alignof(JPH::CollideShapeResult)     == alignof(JPH_CollideShapeResult));
+static_assert(alignof(JPH::TransformedShape)       == alignof(JPH_TransformedShape));
 
 #define ENSURE_ENUM_EQ(c_const, cpp_enum) static_assert(c_const == static_cast<int>(cpp_enum))
 
@@ -1417,6 +1420,81 @@ JPH_Body_GetInverseCenterOfMassTransform(const JPH_Body *in_body, float out_tran
     const JPH::Mat44 m = body->GetInverseCenterOfMassTransform();
     m.StoreFloat4x4(reinterpret_cast<JPH::Float4 *>(out_transform));
 }
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI JPH_AABox
+JPH_Body_GetWorldSpaceBounds(const JPH_Body *in_body)
+{
+    assert(in_body != nullptr);
+    return static_cast<JPH_AABox>(
+        reinterpret_cast<const JPH::Body *>(in_body)->GetWorldSpaceBounds()
+    );
+}
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI JPH_MotionProperties *
+JPH_Body_GetMotionProperties(JPH_Body *in_body)
+{
+    assert(in_body != nullptr);
+    const auto body = reinterpret_cast<JPH::Body *>(in_body);
+    return reinterpret_cast<JPH_MotionProperties *>(body->GetMotionProperties());
+}
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI JPH_MotionProperties *
+JPH_Body_GetMotionPropertiesUnchecked(JPH_Body *in_body)
+{
+    assert(in_body != nullptr);
+    const auto body = reinterpret_cast<JPH::Body *>(in_body);
+    return reinterpret_cast<JPH_MotionProperties *>(body->GetMotionPropertiesUnchecked());
+}
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI uint64_t
+JPH_Body_GetUserData(const JPH_Body *in_body)
+{
+    assert(in_body != nullptr);
+    return reinterpret_cast<const JPH::Body *>(in_body)->GetUserData();
+}
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI void
+JPH_Body_SetUserData(JPH_Body *in_body, uint64_t in_user_data)
+{
+    assert(in_body != nullptr);
+    reinterpret_cast<JPH::Body *>(in_body)->SetUserData(in_user_data);
+}
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI void
+JPH_Body_GetWorldSpaceSurfaceNormal(
+    const JPH_Body *in_body,
+    const JPH_SubShapeID *in_sub_shape_id,
+    const float in_position[3],
+    float out_normal_vector[3]
+)
+{
+    assert(in_body != nullptr);
+    const JPH::Vec3 v = reinterpret_cast<const JPH::Body *>(in_body)->GetWorldSpaceSurfaceNormal(
+        reinterpret_cast<const JPH::SubShapeID &>(in_sub_shape_id),
+        JPH::Vec3(*reinterpret_cast<const JPH::Float3 *>(in_position))
+    );
+    v.StoreFloat3(reinterpret_cast<JPH::Float3 *>(out_normal_vector));
+}
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI JPH_TransformedShape
+JPH_Body_GetTransformedShape(const JPH_Body *in_body)
+{
+    assert(in_body != nullptr);
+    const auto body = reinterpret_cast<const JPH::Body *>(in_body);
+    return static_cast<JPH_TransformedShape>(
+        reinterpret_cast<const JPH::Body *>(in_body)->GetTransformedShape()
+    );
+}
+//--------------------------------------------------------------------------------------------------
+JPH_CAPI JPH_BodyCreationSettings
+JPH_Body_GetBodyCreationSettings(const JPH_Body *in_body)
+{
+    assert(in_body != nullptr);
+    const auto body = reinterpret_cast<const JPH::Body *>(in_body);
+    return static_cast<JPH_BodyCreationSettings>(
+        reinterpret_cast<const JPH::Body *>(in_body)->GetBodyCreationSettings()
+    );
+}
 
 //--------------------------------------------------------------------------------------------------
 //
@@ -1905,7 +1983,7 @@ JPH_MotionProperties_SubAngularVelocityStep(
         JPH::Vec3(*reinterpret_cast<const JPH::Float3 *>(in_angular_velocity_change))
     );
 }
-//--------------------------------------------------------------------------------------------------
+
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/zjolt/libs/JoltC/JoltC.h
+++ b/libs/zjolt/libs/JoltC/JoltC.h
@@ -120,13 +120,10 @@ typedef uint32_t JPH_SubShapeID;
 typedef uint32_t JPH_CollisionGroupID;
 typedef uint32_t JPH_CollisionSubGroupID;
 
-typedef struct JPH_Shape            JPH_Shape;
-typedef struct JPH_PhysicsMaterial  JPH_PhysicsMaterial;
 typedef struct JPH_TempAllocator    JPH_TempAllocator;
 typedef struct JPH_JobSystem        JPH_JobSystem;
 typedef struct JPH_Body             JPH_Body;
 typedef struct JPH_BodyInterface    JPH_BodyInterface;
-typedef struct JPH_GroupFilter      JPH_GroupFilter;
 
 //--------------------------------------------------------------------------------------------------
 //
@@ -169,17 +166,28 @@ typedef struct JPH_StateRecorder        JPH_StateRecorder;
 typedef struct JPH_MassProperties       JPH_MassProperties;
 typedef struct JPH_MotionProperties     JPH_MotionProperties;
 
-typedef struct JPH_CollisionGroup       JPH_CollisionGroup;
 typedef struct JPH_BodyCreationSettings JPH_BodyCreationSettings;
 typedef struct JPH_ContactManifold      JPH_ContactManifold;
 typedef struct JPH_ContactSettings      JPH_ContactSettings;
-typedef struct JPH_SubShapeIDPair       JPH_SubShapeIDPair;
 typedef struct JPH_CollideShapeResult   JPH_CollideShapeResult;
 
 typedef struct JPH_BroadPhaseLayerInterfaceVTable JPH_BroadPhaseLayerInterfaceVTable;
 typedef struct JPH_BodyActivationListenerVTable   JPH_BodyActivationListenerVTable;
 typedef struct JPH_ContactListenerVTable          JPH_ContactListenerVTable;
 
+
+//--------------------------------------------------------------------------------------------------
+//
+// Physics/Collision Types
+//
+//--------------------------------------------------------------------------------------------------
+typedef struct JPH_Shape             JPH_Shape;
+typedef struct JPH_SubShapeIDCreator JPH_SubShapeIDCreator;
+typedef struct JPH_SubShapeIDPair    JPH_SubShapeIDPair;
+typedef struct JPH_PhysicsMaterial   JPH_PhysicsMaterial;
+typedef struct JPH_GroupFilter       JPH_GroupFilter;
+typedef struct JPH_CollisionGroup    JPH_CollisionGroup;
+typedef struct JPH_TransformedShape  JPH_TransformedShape;
 
 //--------------------------------------------------------------------------------------------------
 //
@@ -278,6 +286,13 @@ struct JPH_BodyCreationSettings
     JPH_MassProperties          mass_properties_override;
     const void *                reserved;
     const JPH_Shape *           shape;
+};
+
+// NOTE: Needs to be kept in sync with JPH::SubShapeIDCreator
+struct JPH_SubShapeIDCreator
+{
+    JPH_SubShapeID    id;
+    unsigned int      current_bit;
 };
 
 // NOTE: Needs to be kept in sync with JPH::SubShapeIDPair
@@ -383,6 +398,18 @@ struct JPH_ContactListenerVTable
     void
     (*OnContactRemoved)(void *in_self, const JPH_SubShapeIDPair *in_sub_shape_pair);
 };
+
+// NOTE: Needs to be kept in sync with JPH::TransformedShape
+struct JPH_TransformedShape
+{
+    alignas(16) float      shape_position_com[4];
+    alignas(16) float      shape_rotation[4];
+    const JPH_Shape *      shape;
+    float                  shape_scale[3];
+    JPH_BodyID             body_id;
+    JPH_SubShapeIDCreator  sub_shape_id_creator;
+};
+
 
 //--------------------------------------------------------------------------------------------------
 //
@@ -1130,6 +1157,35 @@ JPH_Body_GetCenterOfMassPosition(const JPH_Body *in_body, float out_position_com
 
 JPH_CAPI void
 JPH_Body_GetInverseCenterOfMassTransform(const JPH_Body *in_body, float out_transform[16]);
+
+JPH_CAPI JPH_AABox
+JPH_Body_GetWorldSpaceBounds(const JPH_Body *in_body);
+
+JPH_CAPI JPH_MotionProperties *
+JPH_Body_GetMotionProperties(JPH_Body *in_body);
+
+JPH_CAPI JPH_MotionProperties *
+JPH_Body_GetMotionPropertiesUnchecked(JPH_Body *in_body);
+
+JPH_CAPI uint64_t
+JPH_Body_GetUserData(const JPH_Body *in_body);
+
+JPH_CAPI void
+JPH_Body_SetUserData(JPH_Body *in_body, uint64_t in_user_data);
+
+JPH_CAPI void
+JPH_Body_GetWorldSpaceSurfaceNormal(
+    const JPH_Body *in_body,
+    const JPH_SubShapeID *in_sub_shape_id,
+    const float in_position[3],
+    float out_normal_vector[3]
+);
+
+JPH_CAPI JPH_TransformedShape
+JPH_Body_GetTransformedShape(const JPH_Body *in_body);
+
+JPH_CAPI JPH_BodyCreationSettings
+JPH_Body_GetBodyCreationSettings(const JPH_Body *in_body);
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/zjolt/libs/JoltC/JoltC.h
+++ b/libs/zjolt/libs/JoltC/JoltC.h
@@ -1158,7 +1158,7 @@ JPH_Body_GetCenterOfMassPosition(const JPH_Body *in_body, float out_position_com
 JPH_CAPI void
 JPH_Body_GetInverseCenterOfMassTransform(const JPH_Body *in_body, float out_transform[16]);
 
-JPH_CAPI JPH_AABox
+JPH_CAPI const JPH_AABox *
 JPH_Body_GetWorldSpaceBounds(const JPH_Body *in_body);
 
 JPH_CAPI JPH_MotionProperties *

--- a/libs/zjolt/libs/JoltC/JoltC.h
+++ b/libs/zjolt/libs/JoltC/JoltC.h
@@ -638,10 +638,12 @@ JPH_MotionProperties_AddAngularVelocityStep(
 );
 
 JPH_CAPI void
-JPH_MotionProperties_SubAngularangularStep(
+JPH_MotionProperties_SubAngularVelocityStep(
     JPH_MotionProperties *in_properties,
     const float in_linear_angular_change[3]
 );
+
+
 
 //--------------------------------------------------------------------------------------------------
 //


### PR DESCRIPTION
- fixes typos in `JPH_MotionProperties`
- defines `JPH_TransformedShape` and `JPH_SubShapeIDCreator`
- defines remaining JPH_Body_* member fns
