### PR TITLE
zglfw/zgui: Added ability to set standard cursors and keep zgui from overriding.

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -53,6 +53,28 @@ pub const MouseButton = enum(i32) {
     eight,
 };
 
+pub const Cursor = extern struct {
+    ptr: *glfwCursor,
+    pub const glfwCursor = opaque {};
+    pub const Shape = enum(c_int) {
+        arrow = 0x00036001,
+        ibeam = 0x00036002,
+        crosshair = 0x00036003,
+        pointing_hand = 0x00036004,
+        resize_ew = 0x00036005,
+        resize_ns = 0x00036006,
+        resize_nwse = 0x00036007,
+        resize_nesw = 0x00036008,
+        resize_all = 0x00036009,
+    };
+
+    pub fn createStandard(shape: Shape) Cursor {
+        if (glfwCreateStandardCursor(@enumToInt(shape))) |ptr| return Cursor{ .ptr = ptr };
+        unreachable;
+    }
+    extern fn glfwCreateStandardCursor(shape: c_int) ?*Cursor.glfwCursor;
+};
+
 pub const Key = enum(i32) {
     unknown = -1,
 
@@ -349,6 +371,13 @@ pub const Window = *opaque {
             yoffset: f64,
         ) callconv(.C) void,
     ) void;
+
+    pub fn setCursor(window: Window, cursor: ?Cursor) void {
+        if (cursor) |c| {
+            glfwSetCursor(window, c.ptr);
+        } else glfwSetCursor(window, null);
+    }
+    extern fn glfwSetCursor(window: Window, cursor: ?*Cursor.glfwCursor) void;
 };
 
 pub fn createWindow(

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1131,6 +1131,10 @@ ZGUI_API void zguiIoSetIniFilename(const char* filename) {
     ImGui::GetIO().IniFilename = filename;
 }
 
+ZGUI_API void zguiIoSetConfigFlags(ImGuiConfigFlags flags) {
+    ImGui::GetIO().ConfigFlags = flags;
+}
+
 ZGUI_API void zguiIoSetDisplaySize(float width, float height) {
     ImGui::GetIO().DisplaySize = { width, height };
 }

--- a/libs/zgui/src/zgui.zig
+++ b/libs/zgui/src/zgui.zig
@@ -51,6 +51,9 @@ pub const io = struct {
     }
     extern fn zguiIoSetIniFilename(filename: [*:0]const u8) void;
 
+    pub const setConfigFlags = zguiIoSetConfigFlags;
+    extern fn zguiIoSetConfigFlags(flags: ConfigFlags) void;
+
     /// `pub fn setDisplaySize(width: f32, height: f32) void`
     pub const setDisplaySize = zguiIoSetDisplaySize;
     extern fn zguiIoSetDisplaySize(width: f32, height: f32) void;
@@ -58,6 +61,18 @@ pub const io = struct {
     /// `pub fn setDisplayFramebufferScale(sx: f32, sy: f32) void`
     pub const setDisplayFramebufferScale = zguiIoSetDisplayFramebufferScale;
     extern fn zguiIoSetDisplayFramebufferScale(sx: f32, sy: f32) void;
+};
+//--------------------------------------------------------------------------------------------------
+pub const ConfigFlags = enum(u32) {
+    none = 0,
+    nav_enable_keyboard = 1 << 0,
+    nav_enable_gamepad = 1 << 1,
+    nav_enable_set_mouse_pos = 1 << 2,
+    nav_no_capture_keyboard = 1 << 3,
+    no_mouse = 1 << 4,
+    no_mouse_cursor_change = 1 << 5,
+    is_srgb = 1 << 20,
+    is_touch_screen = 1 << 21,
 };
 //--------------------------------------------------------------------------------------------------
 const Context = *opaque {};


### PR DESCRIPTION
I attempted to add the `setCursor` method which needed the `Cursor` struct to be created, as well as the `Shape` enum. I followed what was done on the previous wrapper, but maybe you don't want to go that route?

I believe I found an issue while trying this however: I believe this function doesn't work in conjunction with `zgui`, as when setting the cursor to a standard cursor, I get no errors, and see the cursor momentarily when the window loads, but after things are running I lose the ability to set the cursor. I know Dear Imgui has cursor functionality as well and I believe this may be overriding the `glfw` cursor?

So this may be a good way to test or a placeholder PR to serve as a reminder. I believe [this issue](https://github.com/ocornut/imgui/issues/1918) shows we may need to set some flags with zgui to get that functionality back?

EDIT: Found the issue to indeed be what was listed in the above issue, I added a way to set the config flags in `io` and now setting the config flags to `no_mouse_cursor_change` allows glfw to control the mouse cursor visuals normally. This may be something you want to set by default?