### PR TITLE
Avokadoen's combine test case with some suggested fixes by Garett

### DIFF
--- a/libs/zjobs/src/zjobs.zig
+++ b/libs/zjobs/src/zjobs.zig
@@ -577,7 +577,7 @@ pub fn JobQueue(
             const prereq_size = @sizeOf(JobId);
             const max_prereqs = (max_job_size - jobs_size) / prereq_size;
 
-            jobs: *Self = .{},
+            jobs: *Self = undefined,
             prereqs: [max_prereqs]JobId = [_]JobId{JobId.none} ** max_prereqs,
 
             fn exec(job: *@This()) void {

--- a/libs/zjobs/src/zjobs.zig
+++ b/libs/zjobs/src/zjobs.zig
@@ -478,23 +478,9 @@ pub fn JobQueue(
             if (prereqs.len == 0) return JobId.none;
             if (prereqs.len == 1) return prereqs[0];
 
-            var id = JobId.none;
-            var i: usize = 0;
-            const in: []const JobId = prereqs;
-            while (i < in.len) {
-                var job = CombinePrereqsJob{ .jobs = self };
-
-                // copy prereqs to job
-                var o: usize = 0;
-                const out: []JobId = &job.prereqs;
-                while (i < in.len and o < out.len) {
-                    out[o] = in[i];
-                    i += 1;
-                    o += 1;
-                }
-
-                id = try self.schedule(id, job);
-            }
+            var job = CombinePrereqsJob { .jobs = self };
+            std.mem.copy(JobId, &job.prereqs, prereqs);
+            const id = try self.schedule(JobId.none, job);
             return id;
         }
 
@@ -1092,7 +1078,6 @@ test "JobQueue throughput" {
                     "ran on thread id {} and took {}ms",
                     .{ self.thread, self.ms() },
                 );
-
             }
         }
     };

--- a/libs/zjobs/src/zjobs.zig
+++ b/libs/zjobs/src/zjobs.zig
@@ -577,7 +577,7 @@ pub fn JobQueue(
             const prereq_size = @sizeOf(JobId);
             const max_prereqs = (max_job_size - jobs_size) / prereq_size;
 
-            jobs: *Self = undefined,
+            jobs: *Self,
             prereqs: [max_prereqs]JobId = [_]JobId{JobId.none} ** max_prereqs,
 
             fn exec(job: *@This()) void {


### PR DESCRIPTION
Great work from @Avokadoen on the test case for `JobQueue.combine()`.  I chose a different resolution for the compile error they encountered, and restored a loop in `combine()` that allows it to accept more `prereqs` than will fit in a single `CombinePrereqsJob`.  All tests passing on `zig 0.10.0-dev.4280+c3d67c5c4`