### PR TITLE
Offscreen zgui text rendering and transform

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,6 +41,7 @@ pub fn build(b: *std.build.Builder) void {
     installDemo(b, instanced_pills_wgpu.build(b, options), "instanced_pills_wgpu");
     installDemo(b, layers_wgpu.build(b, options), "layers_wgpu");
     installDemo(b, gamepad_wgpu.build(b, options), "gamepad_wgpu");
+    installDemo(b, text_transform_wgpu.build(b, options), "text_transform_wgpu");
 
     //
     // Tests
@@ -109,6 +110,7 @@ const gui_test_wgpu = @import("samples/gui_test_wgpu/build.zig");
 const instanced_pills_wgpu = @import("samples/instanced_pills_wgpu/build.zig");
 const layers_wgpu = @import("samples/layers_wgpu/build.zig");
 const gamepad_wgpu = @import("samples/gamepad_wgpu/build.zig");
+const text_transform_wgpu = @import("samples/text_transform_wgpu/build.zig");
 
 pub const Options = struct {
     build_mode: std.builtin.Mode,

--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -14,6 +14,7 @@ pub fn link(exe: *std.build.LibExeObjStep) void {
     // You may need to remove/change this if you use different backend.
     exe.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_impl_glfw.cpp", cflags);
     exe.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_impl_wgpu.cpp", cflags);
+    exe.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_impl_offscreen_wgpu.cpp", cflags);
 }
 
 pub fn linkNoBackend(exe: *std.build.LibExeObjStep) void {

--- a/libs/zgui/libs/imgui/imgui_impl_offscreen_wgpu.cpp
+++ b/libs/zgui/libs/imgui/imgui_impl_offscreen_wgpu.cpp
@@ -1,0 +1,752 @@
+// dear imgui: Renderer for WebGPU
+// This needs to be used along with a Platform Binding (e.g. GLFW)
+// (Please note that WebGPU is currently experimental, will not run on non-beta browsers, and may break.)
+
+// Implemented features:
+//  [X] Renderer: User texture binding. Use 'WGPUTextureView' as ImTextureID. Read the FAQ about ImTextureID!
+//  [X] Renderer: Support for large meshes (64k+ vertices) with 16-bit indices.
+
+// You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
+// Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
+// If you are new to Dear ImGui, read documentation from the docs/ folder + read the top of imgui.cpp.
+// Read online: https://github.com/ocornut/imgui/tree/master/docs
+
+// CHANGELOG
+// (minor and older changes stripped away, please see git history for details)
+//  2021-11-29: Passing explicit buffer sizes to wgpuRenderPassEncoderSetVertexBuffer()/wgpuRenderPassEncoderSetIndexBuffer().
+//  2021-08-24: Fix for latest specs.
+//  2021-05-24: Add support for draw_data->FramebufferScale.
+//  2021-05-19: Replaced direct access to ImDrawCmd::TextureId with a call to ImDrawCmd::GetTexID(). (will become a requirement)
+//  2021-05-16: Update to latest WebGPU specs (compatible with Emscripten 2.0.20 and Chrome Canary 92).
+//  2021-02-18: Change blending equation to preserve alpha in output buffer.
+//  2021-01-28: Initial version.
+
+#include "imgui.h"
+#include <limits.h>
+#include <webgpu/webgpu.h>
+
+#define HAS_EMSCRIPTEN_VERSION(major, minor, tiny) (__EMSCRIPTEN_major__ > (major) || (__EMSCRIPTEN_major__ == (major) && __EMSCRIPTEN_minor__ > (minor)) || (__EMSCRIPTEN_major__ == (major) && __EMSCRIPTEN_minor__ == (minor) && __EMSCRIPTEN_tiny__ >= (tiny)))
+
+#if defined(__EMSCRIPTEN__) && !HAS_EMSCRIPTEN_VERSION(2, 0, 20)
+#error "Requires at least emscripten 2.0.20"
+#endif
+
+// Dear ImGui prototypes from imgui_internal.h
+extern ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed = 0);
+
+// mziulek: We removed header file and declare all our external functions here.
+extern "C" {
+
+struct Config
+{
+    unsigned int pipeline_multisample_count;
+    unsigned int texture_filter_mode;
+};
+bool ImGui_ImplOffscreenWGPU_Init(WGPUDevice device, int num_frames_in_flight, WGPUTextureFormat rt_format, const Config* config);
+void ImGui_ImplOffscreenWGPU_Shutdown(void);
+void ImGui_ImplOffscreenWGPU_NewFrame(void);
+void ImGui_ImplOffscreenWGPU_RenderDrawData(ImDrawData* draw_data, WGPURenderPassEncoder pass_encoder);
+
+// Use if you want to reset your rendering device without losing Dear ImGui state.
+void ImGui_ImplOffscreenWGPU_InvalidateDeviceObjects(void);
+bool ImGui_ImplOffscreenWGPU_CreateDeviceObjects(void);
+
+} // extern "C"
+
+// WebGPU data
+static WGPUDevice               g_wgpuDevice = NULL;
+static WGPUQueue                g_defaultQueue = NULL;
+static WGPUTextureFormat        g_renderTargetFormat = WGPUTextureFormat_Undefined;
+static WGPURenderPipeline       g_pipelineState = NULL;
+
+struct RenderResources
+{
+    WGPUTexture         FontTexture;            // Font texture
+    WGPUTextureView     FontTextureView;        // Texture view for font texture
+    WGPUSampler         Sampler;                // Sampler for the font texture
+    WGPUBuffer          Uniforms;               // Shader uniforms
+    WGPUBindGroup       CommonBindGroup;        // Resources bind-group to bind the common resources to pipeline
+    ImGuiStorage        ImageBindGroups;        // Resources bind-group to bind the font/image resources to pipeline (this is a key->value map)
+    WGPUBindGroup       ImageBindGroup;         // Default font-resource of Dear ImGui
+    WGPUBindGroupLayout ImageBindGroupLayout;   // Cache layout used for the image bind group. Avoids allocating unnecessary JS objects when working with WebASM
+};
+static RenderResources  g_resources;
+
+struct FrameResources
+{
+    WGPUBuffer  IndexBuffer;
+    WGPUBuffer  VertexBuffer;
+    ImDrawIdx*  IndexBufferHost;
+    ImDrawVert* VertexBufferHost;
+    int         IndexBufferSize;
+    int         VertexBufferSize;
+};
+static FrameResources*  g_pFrameResources = NULL;
+static unsigned int     g_numFramesInFlight = 0;
+static unsigned int     g_frameIndex = UINT_MAX;
+
+struct Uniforms
+{
+    float MVP[4][4];
+};
+
+
+static Config g_config;
+
+//-----------------------------------------------------------------------------
+// SHADERS
+//-----------------------------------------------------------------------------
+
+// glsl_shader.vert, compiled with:
+// # glslangValidator -V -x -o glsl_shader.vert.u32 glsl_shader.vert
+/*
+#version 450 core
+layout(location = 0) in vec2 aPos;
+layout(location = 1) in vec2 aUV;
+layout(location = 2) in vec4 aColor;
+layout(set=0, binding = 0) uniform transform { mat4 mvp; };
+
+out gl_PerVertex { vec4 gl_Position; };
+layout(location = 0) out struct { vec4 Color; vec2 UV; } Out;
+
+void main()
+{
+    Out.Color = aColor;
+    Out.UV = aUV;
+    gl_Position = mvp * vec4(aPos, 0, 1);
+}
+*/
+static uint32_t __glsl_shader_vert_spv[] =
+{
+    0x07230203,0x00010000,0x00080007,0x0000002c,0x00000000,0x00020011,0x00000001,0x0006000b,
+    0x00000001,0x4c534c47,0x6474732e,0x3035342e,0x00000000,0x0003000e,0x00000000,0x00000001,
+    0x000a000f,0x00000000,0x00000004,0x6e69616d,0x00000000,0x0000000b,0x0000000f,0x00000015,
+    0x0000001b,0x00000023,0x00030003,0x00000002,0x000001c2,0x00040005,0x00000004,0x6e69616d,
+    0x00000000,0x00030005,0x00000009,0x00000000,0x00050006,0x00000009,0x00000000,0x6f6c6f43,
+    0x00000072,0x00040006,0x00000009,0x00000001,0x00005655,0x00030005,0x0000000b,0x0074754f,
+    0x00040005,0x0000000f,0x6c6f4361,0x0000726f,0x00030005,0x00000015,0x00565561,0x00060005,
+    0x00000019,0x505f6c67,0x65567265,0x78657472,0x00000000,0x00060006,0x00000019,0x00000000,
+    0x505f6c67,0x7469736f,0x006e6f69,0x00030005,0x0000001b,0x00000000,0x00050005,0x0000001d,
+    0x6e617274,0x726f6673,0x0000006d,0x00040006,0x0000001d,0x00000000,0x0070766d,0x00030005,
+    0x0000001f,0x00000000,0x00040005,0x00000023,0x736f5061,0x00000000,0x00040047,0x0000000b,
+    0x0000001e,0x00000000,0x00040047,0x0000000f,0x0000001e,0x00000002,0x00040047,0x00000015,
+    0x0000001e,0x00000001,0x00050048,0x00000019,0x00000000,0x0000000b,0x00000000,0x00030047,
+    0x00000019,0x00000002,0x00040048,0x0000001d,0x00000000,0x00000005,0x00050048,0x0000001d,
+    0x00000000,0x00000023,0x00000000,0x00050048,0x0000001d,0x00000000,0x00000007,0x00000010,
+    0x00030047,0x0000001d,0x00000002,0x00040047,0x0000001f,0x00000022,0x00000000,0x00040047,
+    0x0000001f,0x00000021,0x00000000,0x00040047,0x00000023,0x0000001e,0x00000000,0x00020013,
+    0x00000002,0x00030021,0x00000003,0x00000002,0x00030016,0x00000006,0x00000020,0x00040017,
+    0x00000007,0x00000006,0x00000004,0x00040017,0x00000008,0x00000006,0x00000002,0x0004001e,
+    0x00000009,0x00000007,0x00000008,0x00040020,0x0000000a,0x00000003,0x00000009,0x0004003b,
+    0x0000000a,0x0000000b,0x00000003,0x00040015,0x0000000c,0x00000020,0x00000001,0x0004002b,
+    0x0000000c,0x0000000d,0x00000000,0x00040020,0x0000000e,0x00000001,0x00000007,0x0004003b,
+    0x0000000e,0x0000000f,0x00000001,0x00040020,0x00000011,0x00000003,0x00000007,0x0004002b,
+    0x0000000c,0x00000013,0x00000001,0x00040020,0x00000014,0x00000001,0x00000008,0x0004003b,
+    0x00000014,0x00000015,0x00000001,0x00040020,0x00000017,0x00000003,0x00000008,0x0003001e,
+    0x00000019,0x00000007,0x00040020,0x0000001a,0x00000003,0x00000019,0x0004003b,0x0000001a,
+    0x0000001b,0x00000003,0x00040018,0x0000001c,0x00000007,0x00000004,0x0003001e,0x0000001d,
+    0x0000001c,0x00040020,0x0000001e,0x00000002,0x0000001d,0x0004003b,0x0000001e,0x0000001f,
+    0x00000002,0x00040020,0x00000020,0x00000002,0x0000001c,0x0004003b,0x00000014,0x00000023,
+    0x00000001,0x0004002b,0x00000006,0x00000025,0x00000000,0x0004002b,0x00000006,0x00000026,
+    0x3f800000,0x00050036,0x00000002,0x00000004,0x00000000,0x00000003,0x000200f8,0x00000005,
+    0x0004003d,0x00000007,0x00000010,0x0000000f,0x00050041,0x00000011,0x00000012,0x0000000b,
+    0x0000000d,0x0003003e,0x00000012,0x00000010,0x0004003d,0x00000008,0x00000016,0x00000015,
+    0x00050041,0x00000017,0x00000018,0x0000000b,0x00000013,0x0003003e,0x00000018,0x00000016,
+    0x00050041,0x00000020,0x00000021,0x0000001f,0x0000000d,0x0004003d,0x0000001c,0x00000022,
+    0x00000021,0x0004003d,0x00000008,0x00000024,0x00000023,0x00050051,0x00000006,0x00000027,
+    0x00000024,0x00000000,0x00050051,0x00000006,0x00000028,0x00000024,0x00000001,0x00070050,
+    0x00000007,0x00000029,0x00000027,0x00000028,0x00000025,0x00000026,0x00050091,0x00000007,
+    0x0000002a,0x00000022,0x00000029,0x00050041,0x00000011,0x0000002b,0x0000001b,0x0000000d,
+    0x0003003e,0x0000002b,0x0000002a,0x000100fd,0x00010038
+};
+
+// glsl_shader.frag, compiled with:
+// # glslangValidator -V -x -o glsl_shader.frag.u32 glsl_shader.frag
+/*
+#version 450 core
+layout(location = 0) out vec4 fColor;
+layout(set=0, binding=1) uniform sampler s;
+layout(set=1, binding=0) uniform texture2D t;
+layout(location = 0) in struct { vec4 Color; vec2 UV; } In;
+void main()
+{
+    fColor = In.Color * texture(sampler2D(t, s), In.UV.st);
+}
+*/
+static uint32_t __glsl_shader_frag_spv[] =
+{
+    0x07230203,0x00010000,0x00080007,0x00000023,0x00000000,0x00020011,0x00000001,0x0006000b,
+    0x00000001,0x4c534c47,0x6474732e,0x3035342e,0x00000000,0x0003000e,0x00000000,0x00000001,
+    0x0007000f,0x00000004,0x00000004,0x6e69616d,0x00000000,0x00000009,0x0000000d,0x00030010,
+    0x00000004,0x00000007,0x00030003,0x00000002,0x000001c2,0x00040005,0x00000004,0x6e69616d,
+    0x00000000,0x00040005,0x00000009,0x6c6f4366,0x0000726f,0x00030005,0x0000000b,0x00000000,
+    0x00050006,0x0000000b,0x00000000,0x6f6c6f43,0x00000072,0x00040006,0x0000000b,0x00000001,
+    0x00005655,0x00030005,0x0000000d,0x00006e49,0x00030005,0x00000015,0x00000074,0x00030005,
+    0x00000019,0x00000073,0x00040047,0x00000009,0x0000001e,0x00000000,0x00040047,0x0000000d,
+    0x0000001e,0x00000000,0x00040047,0x00000015,0x00000022,0x00000001,0x00040047,0x00000015,
+    0x00000021,0x00000000,0x00040047,0x00000019,0x00000022,0x00000000,0x00040047,0x00000019,
+    0x00000021,0x00000001,0x00020013,0x00000002,0x00030021,0x00000003,0x00000002,0x00030016,
+    0x00000006,0x00000020,0x00040017,0x00000007,0x00000006,0x00000004,0x00040020,0x00000008,
+    0x00000003,0x00000007,0x0004003b,0x00000008,0x00000009,0x00000003,0x00040017,0x0000000a,
+    0x00000006,0x00000002,0x0004001e,0x0000000b,0x00000007,0x0000000a,0x00040020,0x0000000c,
+    0x00000001,0x0000000b,0x0004003b,0x0000000c,0x0000000d,0x00000001,0x00040015,0x0000000e,
+    0x00000020,0x00000001,0x0004002b,0x0000000e,0x0000000f,0x00000000,0x00040020,0x00000010,
+    0x00000001,0x00000007,0x00090019,0x00000013,0x00000006,0x00000001,0x00000000,0x00000000,
+    0x00000000,0x00000001,0x00000000,0x00040020,0x00000014,0x00000000,0x00000013,0x0004003b,
+    0x00000014,0x00000015,0x00000000,0x0002001a,0x00000017,0x00040020,0x00000018,0x00000000,
+    0x00000017,0x0004003b,0x00000018,0x00000019,0x00000000,0x0003001b,0x0000001b,0x00000013,
+    0x0004002b,0x0000000e,0x0000001d,0x00000001,0x00040020,0x0000001e,0x00000001,0x0000000a,
+    0x00050036,0x00000002,0x00000004,0x00000000,0x00000003,0x000200f8,0x00000005,0x00050041,
+    0x00000010,0x00000011,0x0000000d,0x0000000f,0x0004003d,0x00000007,0x00000012,0x00000011,
+    0x0004003d,0x00000013,0x00000016,0x00000015,0x0004003d,0x00000017,0x0000001a,0x00000019,
+    0x00050056,0x0000001b,0x0000001c,0x00000016,0x0000001a,0x00050041,0x0000001e,0x0000001f,
+    0x0000000d,0x0000001d,0x0004003d,0x0000000a,0x00000020,0x0000001f,0x00050057,0x00000007,
+    0x00000021,0x0000001c,0x00000020,0x00050085,0x00000007,0x00000022,0x00000012,0x00000021,
+    0x0003003e,0x00000009,0x00000022,0x000100fd,0x00010038
+};
+
+static void SafeRelease(ImDrawIdx*& res)
+{
+    if (res)
+        delete[] res;
+    res = NULL;
+}
+static void SafeRelease(ImDrawVert*& res)
+{
+    if (res)
+        delete[] res;
+    res = NULL;
+}
+static void SafeRelease(WGPUBindGroupLayout& res)
+{
+    if (res)
+        wgpuBindGroupLayoutRelease(res);
+    res = NULL;
+}
+static void SafeRelease(WGPUBindGroup& res)
+{
+    if (res)
+        wgpuBindGroupRelease(res);
+    res = NULL;
+}
+static void SafeRelease(WGPUBuffer& res)
+{
+    if (res)
+        wgpuBufferRelease(res);
+    res = NULL;
+}
+static void SafeRelease(WGPURenderPipeline& res)
+{
+    if (res)
+        wgpuRenderPipelineRelease(res);
+    res = NULL;
+}
+static void SafeRelease(WGPUSampler& res)
+{
+    if (res)
+        wgpuSamplerRelease(res);
+    res = NULL;
+}
+static void SafeRelease(WGPUShaderModule& res)
+{
+    if (res)
+        wgpuShaderModuleRelease(res);
+    res = NULL;
+}
+static void SafeRelease(WGPUTextureView& res)
+{
+    if (res)
+        wgpuTextureViewRelease(res);
+    res = NULL;
+}
+static void SafeRelease(WGPUTexture& res)
+{
+    if (res)
+        wgpuTextureRelease(res);
+    res = NULL;
+}
+
+static void SafeRelease(RenderResources& res)
+{
+    SafeRelease(res.FontTexture);
+    SafeRelease(res.FontTextureView);
+    SafeRelease(res.Sampler);
+    SafeRelease(res.Uniforms);
+    SafeRelease(res.CommonBindGroup);
+    SafeRelease(res.ImageBindGroup);
+    SafeRelease(res.ImageBindGroupLayout);
+};
+
+static void SafeRelease(FrameResources& res)
+{
+    SafeRelease(res.IndexBuffer);
+    SafeRelease(res.VertexBuffer);
+    SafeRelease(res.IndexBufferHost);
+    SafeRelease(res.VertexBufferHost);
+}
+
+static WGPUProgrammableStageDescriptor ImGui_ImplOffscreenWGPU_CreateShaderModule(uint32_t* binary_data, uint32_t binary_data_size)
+{
+    WGPUShaderModuleSPIRVDescriptor spirv_desc = {};
+    spirv_desc.chain.sType = WGPUSType_ShaderModuleSPIRVDescriptor;
+    spirv_desc.codeSize = binary_data_size;
+    spirv_desc.code = binary_data;
+
+    WGPUShaderModuleDescriptor desc = {};
+    desc.nextInChain = reinterpret_cast<WGPUChainedStruct*>(&spirv_desc);
+
+    WGPUProgrammableStageDescriptor stage_desc = {};
+    stage_desc.module = wgpuDeviceCreateShaderModule(g_wgpuDevice, &desc);
+    stage_desc.entryPoint = "main";
+    return stage_desc;
+}
+
+static WGPUBindGroup ImGui_ImplOffscreenWGPU_CreateImageBindGroup(WGPUBindGroupLayout layout, WGPUTextureView texture)
+{
+    WGPUBindGroupEntry image_bg_entries[] = { { nullptr, 0, 0, 0, 0, 0, texture } };
+
+    WGPUBindGroupDescriptor image_bg_descriptor = {};
+    image_bg_descriptor.layout = layout;
+    image_bg_descriptor.entryCount = sizeof(image_bg_entries) / sizeof(WGPUBindGroupEntry);
+    image_bg_descriptor.entries = image_bg_entries;
+    return wgpuDeviceCreateBindGroup(g_wgpuDevice, &image_bg_descriptor);
+}
+
+static void ImGui_ImplOffscreenWGPU_SetupRenderState(ImDrawData* draw_data, WGPURenderPassEncoder ctx, FrameResources* fr)
+{
+    // Setup orthographic projection matrix into our constant buffer
+    // Our visible imgui space lies from draw_data->DisplayPos (top left) to draw_data->DisplayPos+data_data->DisplaySize (bottom right).
+    {
+        float L = draw_data->DisplayPos.x;
+        float R = draw_data->DisplayPos.x + draw_data->DisplaySize.x;
+        float T = draw_data->DisplayPos.y;
+        float B = draw_data->DisplayPos.y + draw_data->DisplaySize.y;
+        float mvp[4][4] =
+        {
+            { 2.0f/(R-L),   0.0f,           0.0f,       0.0f },
+            { 0.0f,         2.0f/(T-B),     0.0f,       0.0f },
+            { 0.0f,         0.0f,           0.5f,       0.0f },
+            { (R+L)/(L-R),  (T+B)/(B-T),    0.5f,       1.0f },
+        };
+        wgpuQueueWriteBuffer(g_defaultQueue, g_resources.Uniforms, 0, mvp, sizeof(mvp));
+    }
+
+    // Setup viewport
+    wgpuRenderPassEncoderSetViewport(ctx, 0, 0, draw_data->FramebufferScale.x * draw_data->DisplaySize.x, draw_data->FramebufferScale.y * draw_data->DisplaySize.y, 0, 1);
+
+    // Bind shader and vertex buffers
+    wgpuRenderPassEncoderSetVertexBuffer(ctx, 0, fr->VertexBuffer, 0, fr->VertexBufferSize * sizeof(ImDrawVert));
+    wgpuRenderPassEncoderSetIndexBuffer(ctx, fr->IndexBuffer, sizeof(ImDrawIdx) == 2 ? WGPUIndexFormat_Uint16 : WGPUIndexFormat_Uint32, 0, fr->IndexBufferSize * sizeof(ImDrawIdx));
+    wgpuRenderPassEncoderSetPipeline(ctx, g_pipelineState);
+    wgpuRenderPassEncoderSetBindGroup(ctx, 0, g_resources.CommonBindGroup, 0, NULL);
+
+    // Setup blend factor
+    WGPUColor blend_color = { 0.f, 0.f, 0.f, 0.f };
+    wgpuRenderPassEncoderSetBlendConstant(ctx, &blend_color);
+}
+
+// Render function
+// (this used to be set in io.RenderDrawListsFn and called by ImGui::Render(), but you can now call this directly from your main loop)
+void ImGui_ImplOffscreenWGPU_RenderDrawData(ImDrawData* draw_data, WGPURenderPassEncoder pass_encoder)
+{
+    // Avoid rendering when minimized
+    if (draw_data->DisplaySize.x <= 0.0f || draw_data->DisplaySize.y <= 0.0f)
+        return;
+
+    // FIXME: Assuming that this only gets called once per frame!
+    // If not, we can't just re-allocate the IB or VB, we'll have to do a proper allocator.
+    g_frameIndex = g_frameIndex + 1;
+    FrameResources* fr = &g_pFrameResources[g_frameIndex % g_numFramesInFlight];
+
+    // Create and grow vertex/index buffers if needed
+    if (fr->VertexBuffer == NULL || fr->VertexBufferSize < draw_data->TotalVtxCount)
+    {
+        if (fr->VertexBuffer)
+        {
+            wgpuBufferDestroy(fr->VertexBuffer);
+            wgpuBufferRelease(fr->VertexBuffer);
+        }
+        SafeRelease(fr->VertexBufferHost);
+        fr->VertexBufferSize = draw_data->TotalVtxCount + 5000;
+
+        WGPUBufferDescriptor vb_desc =
+        {
+            NULL,
+            "Dear ImGui Vertex buffer",
+            WGPUBufferUsage_CopyDst | WGPUBufferUsage_Vertex,
+            fr->VertexBufferSize * sizeof(ImDrawVert),
+            false
+        };
+        fr->VertexBuffer = wgpuDeviceCreateBuffer(g_wgpuDevice, &vb_desc);
+        if (!fr->VertexBuffer)
+            return;
+
+        fr->VertexBufferHost = new ImDrawVert[fr->VertexBufferSize];
+    }
+    if (fr->IndexBuffer == NULL || fr->IndexBufferSize < draw_data->TotalIdxCount)
+    {
+        if (fr->IndexBuffer)
+        {
+            wgpuBufferDestroy(fr->IndexBuffer);
+            wgpuBufferRelease(fr->IndexBuffer);
+        }
+        SafeRelease(fr->IndexBufferHost);
+        fr->IndexBufferSize = draw_data->TotalIdxCount + 10000;
+
+        WGPUBufferDescriptor ib_desc =
+        {
+            NULL,
+            "Dear ImGui Index buffer",
+            WGPUBufferUsage_CopyDst | WGPUBufferUsage_Index,
+            fr->IndexBufferSize * sizeof(ImDrawIdx),
+            false
+        };
+        fr->IndexBuffer = wgpuDeviceCreateBuffer(g_wgpuDevice, &ib_desc);
+        if (!fr->IndexBuffer)
+            return;
+
+        fr->IndexBufferHost = new ImDrawIdx[fr->IndexBufferSize];
+    }
+
+    // Upload vertex/index data into a single contiguous GPU buffer
+    ImDrawVert* vtx_dst = (ImDrawVert*)fr->VertexBufferHost;
+    ImDrawIdx* idx_dst = (ImDrawIdx*)fr->IndexBufferHost;
+    for (int n = 0; n < draw_data->CmdListsCount; n++)
+    {
+        const ImDrawList* cmd_list = draw_data->CmdLists[n];
+        memcpy(vtx_dst, cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
+        memcpy(idx_dst, cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
+        vtx_dst += cmd_list->VtxBuffer.Size;
+        idx_dst += cmd_list->IdxBuffer.Size;
+    }
+    int64_t vb_write_size = ((char*)vtx_dst - (char*)fr->VertexBufferHost + 3) & ~3;
+    int64_t ib_write_size = ((char*)idx_dst - (char*)fr->IndexBufferHost  + 3) & ~3;
+    wgpuQueueWriteBuffer(g_defaultQueue, fr->VertexBuffer, 0, fr->VertexBufferHost, vb_write_size);
+    wgpuQueueWriteBuffer(g_defaultQueue, fr->IndexBuffer,  0, fr->IndexBufferHost,  ib_write_size);
+
+    // Setup desired render state
+    ImGui_ImplOffscreenWGPU_SetupRenderState(draw_data, pass_encoder, fr);
+
+    // Render command lists
+    // (Because we merged all buffers into a single one, we maintain our own offset into them)
+    int global_vtx_offset = 0;
+    int global_idx_offset = 0;
+    ImVec2 clip_scale = draw_data->FramebufferScale;
+    ImVec2 clip_off = draw_data->DisplayPos;
+    for (int n = 0; n < draw_data->CmdListsCount; n++)
+    {
+        const ImDrawList* cmd_list = draw_data->CmdLists[n];
+        for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)
+        {
+            const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];
+            if (pcmd->UserCallback != NULL)
+            {
+                // User callback, registered via ImDrawList::AddCallback()
+                // (ImDrawCallback_ResetRenderState is a special callback value used by the user to request the renderer to reset render state.)
+                if (pcmd->UserCallback == ImDrawCallback_ResetRenderState)
+                    ImGui_ImplOffscreenWGPU_SetupRenderState(draw_data, pass_encoder, fr);
+                else
+                    pcmd->UserCallback(cmd_list, pcmd);
+            }
+            else
+            {
+                // Bind custom texture
+                ImTextureID tex_id = pcmd->GetTexID();
+                ImGuiID tex_id_hash = ImHashData(&tex_id, sizeof(tex_id));
+                auto bind_group = g_resources.ImageBindGroups.GetVoidPtr(tex_id_hash);
+                if (bind_group)
+                {
+                    wgpuRenderPassEncoderSetBindGroup(pass_encoder, 1, (WGPUBindGroup)bind_group, 0, NULL);
+                }
+                else
+                {
+                    WGPUBindGroup image_bind_group = ImGui_ImplOffscreenWGPU_CreateImageBindGroup(g_resources.ImageBindGroupLayout, (WGPUTextureView)tex_id);
+                    g_resources.ImageBindGroups.SetVoidPtr(tex_id_hash, image_bind_group);
+                    wgpuRenderPassEncoderSetBindGroup(pass_encoder, 1, image_bind_group, 0, NULL);
+                }
+
+                // Project scissor/clipping rectangles into framebuffer space
+                ImVec2 clip_min((pcmd->ClipRect.x - clip_off.x) * clip_scale.x, (pcmd->ClipRect.y - clip_off.y) * clip_scale.y);
+                ImVec2 clip_max((pcmd->ClipRect.z - clip_off.x) * clip_scale.x, (pcmd->ClipRect.w - clip_off.y) * clip_scale.y);
+                if (clip_max.x <= clip_min.x || clip_max.y <= clip_min.y)
+                    continue;
+
+                // mziulek: Fixes 'Popups and Modal windows->Modals->Stacked modals..' from showDemoWindow().
+                if (clip_min.x < 0.0f) clip_min.x = 0.0f;
+                if (clip_min.y < 0.0f) clip_min.y = 0.0f;
+                if (clip_max.x > draw_data->DisplaySize.x) clip_max.x = draw_data->DisplaySize.x;
+                if (clip_max.y > draw_data->DisplaySize.y) clip_max.y = draw_data->DisplaySize.y;
+
+                // Apply scissor/clipping rectangle, Draw
+                wgpuRenderPassEncoderSetScissorRect(pass_encoder, (uint32_t)clip_min.x, (uint32_t)clip_min.y, (uint32_t)(clip_max.x - clip_min.x), (uint32_t)(clip_max.y - clip_min.y));
+                wgpuRenderPassEncoderDrawIndexed(pass_encoder, pcmd->ElemCount, 1, pcmd->IdxOffset + global_idx_offset, pcmd->VtxOffset + global_vtx_offset, 0);
+            }
+        }
+        global_idx_offset += cmd_list->IdxBuffer.Size;
+        global_vtx_offset += cmd_list->VtxBuffer.Size;
+    }
+}
+
+static void ImGui_ImplOffscreenWGPU_CreateFontsTexture()
+{
+    // Build texture atlas
+    ImGuiIO& io = ImGui::GetIO();
+    unsigned char* pixels;
+    int width, height, size_pp;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height, &size_pp);
+
+    // Upload texture to graphics system
+    {
+        WGPUTextureDescriptor tex_desc = {};
+        tex_desc.label = "Dear ImGui Font Texture";
+        tex_desc.dimension = WGPUTextureDimension_2D;
+        tex_desc.size.width = width;
+        tex_desc.size.height = height;
+        tex_desc.size.depthOrArrayLayers = 1;
+        tex_desc.sampleCount = 1;
+        tex_desc.format = WGPUTextureFormat_RGBA8Unorm;
+        tex_desc.mipLevelCount = 1;
+        tex_desc.usage = WGPUTextureUsage_CopyDst | WGPUTextureUsage_TextureBinding;
+        g_resources.FontTexture = wgpuDeviceCreateTexture(g_wgpuDevice, &tex_desc);
+
+        WGPUTextureViewDescriptor tex_view_desc = {};
+        tex_view_desc.format = WGPUTextureFormat_RGBA8Unorm;
+        tex_view_desc.dimension = WGPUTextureViewDimension_2D;
+        tex_view_desc.baseMipLevel = 0;
+        tex_view_desc.mipLevelCount = 1;
+        tex_view_desc.baseArrayLayer = 0;
+        tex_view_desc.arrayLayerCount = 1;
+        tex_view_desc.aspect = WGPUTextureAspect_All;
+        g_resources.FontTextureView = wgpuTextureCreateView(g_resources.FontTexture, &tex_view_desc);
+    }
+
+    // Upload texture data
+    {
+        WGPUImageCopyTexture dst_view = {};
+        dst_view.texture = g_resources.FontTexture;
+        dst_view.mipLevel = 0;
+        dst_view.origin = { 0, 0, 0 };
+        dst_view.aspect = WGPUTextureAspect_All;
+        WGPUTextureDataLayout layout = {};
+        layout.offset = 0;
+        layout.bytesPerRow = width * size_pp;
+        layout.rowsPerImage = height;
+        WGPUExtent3D size = { (uint32_t)width, (uint32_t)height, 1 };
+        wgpuQueueWriteTexture(g_defaultQueue, &dst_view, pixels, (uint32_t)(width * size_pp * height), &layout, &size);
+    }
+
+    // Create the associated sampler
+    // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
+    {
+        const WGPUFilterMode filter_mode = g_config.texture_filter_mode == 1 ? WGPUFilterMode_Linear : WGPUFilterMode_Nearest;
+        WGPUSamplerDescriptor sampler_desc = {};
+        sampler_desc.minFilter = filter_mode;
+        sampler_desc.magFilter = filter_mode;
+        sampler_desc.mipmapFilter = filter_mode;
+        sampler_desc.addressModeU = WGPUAddressMode_Repeat;
+        sampler_desc.addressModeV = WGPUAddressMode_Repeat;
+        sampler_desc.addressModeW = WGPUAddressMode_Repeat;
+        sampler_desc.maxAnisotropy = 1;
+        g_resources.Sampler = wgpuDeviceCreateSampler(g_wgpuDevice, &sampler_desc);
+    }
+
+    // Store our identifier
+    static_assert(sizeof(ImTextureID) >= sizeof(g_resources.FontTexture), "Can't pack descriptor handle into TexID, 32-bit not supported yet.");
+    io.Fonts->SetTexID((ImTextureID)g_resources.FontTextureView);
+}
+
+static void ImGui_ImplOffscreenWGPU_CreateUniformBuffer()
+{
+    WGPUBufferDescriptor ub_desc =
+    {
+        NULL,
+        "Dear ImGui Uniform buffer",
+        WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform,
+        sizeof(Uniforms),
+        false
+    };
+    g_resources.Uniforms = wgpuDeviceCreateBuffer(g_wgpuDevice, &ub_desc);
+}
+
+bool ImGui_ImplOffscreenWGPU_CreateDeviceObjects(void)
+{
+    if (!g_wgpuDevice)
+        return false;
+    if (g_pipelineState)
+        ImGui_ImplOffscreenWGPU_InvalidateDeviceObjects();
+
+    // Create render pipeline
+    WGPURenderPipelineDescriptor graphics_pipeline_desc = {};
+    graphics_pipeline_desc.primitive.topology = WGPUPrimitiveTopology_TriangleList;
+    graphics_pipeline_desc.primitive.stripIndexFormat = WGPUIndexFormat_Undefined;
+    graphics_pipeline_desc.primitive.frontFace = WGPUFrontFace_CW;
+    graphics_pipeline_desc.primitive.cullMode = WGPUCullMode_None;
+    graphics_pipeline_desc.multisample.count = g_config.pipeline_multisample_count;
+    graphics_pipeline_desc.multisample.mask = UINT_MAX;
+    graphics_pipeline_desc.multisample.alphaToCoverageEnabled = false;
+    graphics_pipeline_desc.layout = nullptr; // Use automatic layout generation
+
+    // Create the vertex shader
+    WGPUProgrammableStageDescriptor vertex_shader_desc = ImGui_ImplOffscreenWGPU_CreateShaderModule(__glsl_shader_vert_spv, sizeof(__glsl_shader_vert_spv) / sizeof(uint32_t));
+    graphics_pipeline_desc.vertex.module = vertex_shader_desc.module;
+    graphics_pipeline_desc.vertex.entryPoint = vertex_shader_desc.entryPoint;
+
+    // Vertex input configuration
+    WGPUVertexAttribute attribute_desc[] =
+    {
+        { WGPUVertexFormat_Float32x2, (uint64_t)IM_OFFSETOF(ImDrawVert, pos), 0 },
+        { WGPUVertexFormat_Float32x2, (uint64_t)IM_OFFSETOF(ImDrawVert, uv),  1 },
+        { WGPUVertexFormat_Unorm8x4,  (uint64_t)IM_OFFSETOF(ImDrawVert, col), 2 },
+    };
+
+    WGPUVertexBufferLayout buffer_layouts[1];
+    buffer_layouts[0].arrayStride = sizeof(ImDrawVert);
+    buffer_layouts[0].stepMode = WGPUVertexStepMode_Vertex;
+    buffer_layouts[0].attributeCount = 3;
+    buffer_layouts[0].attributes = attribute_desc;
+
+    graphics_pipeline_desc.vertex.bufferCount = 1;
+    graphics_pipeline_desc.vertex.buffers = buffer_layouts;
+
+    // Create the pixel shader
+    WGPUProgrammableStageDescriptor pixel_shader_desc = ImGui_ImplOffscreenWGPU_CreateShaderModule(__glsl_shader_frag_spv, sizeof(__glsl_shader_frag_spv) / sizeof(uint32_t));
+
+    // Create the blending setup
+    WGPUBlendState blend_state = {};
+    blend_state.alpha.operation = WGPUBlendOperation_Add;
+    blend_state.alpha.srcFactor = WGPUBlendFactor_One;
+    blend_state.alpha.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
+    blend_state.color.operation = WGPUBlendOperation_Add;
+    blend_state.color.srcFactor = WGPUBlendFactor_SrcAlpha;
+    blend_state.color.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
+
+    WGPUColorTargetState color_state = {};
+    color_state.format = g_renderTargetFormat;
+    color_state.blend = &blend_state;
+    color_state.writeMask = WGPUColorWriteMask_All;
+
+    WGPUFragmentState fragment_state = {};
+    fragment_state.module = pixel_shader_desc.module;
+    fragment_state.entryPoint = pixel_shader_desc.entryPoint;
+    fragment_state.targetCount = 1;
+    fragment_state.targets = &color_state;
+
+    graphics_pipeline_desc.fragment = &fragment_state;
+
+    // Create depth-stencil State
+    WGPUDepthStencilState depth_stencil_state = {};
+    depth_stencil_state.depthBias = 0;
+    depth_stencil_state.depthBiasClamp = 0;
+    depth_stencil_state.depthBiasSlopeScale = 0;
+
+    // Configure disabled depth-stencil state
+    graphics_pipeline_desc.depthStencil = nullptr;
+
+    g_pipelineState = wgpuDeviceCreateRenderPipeline(g_wgpuDevice, &graphics_pipeline_desc);
+
+    ImGui_ImplOffscreenWGPU_CreateFontsTexture();
+    ImGui_ImplOffscreenWGPU_CreateUniformBuffer();
+
+    // Create resource bind group
+    WGPUBindGroupLayout bg_layouts[2];
+    bg_layouts[0] = wgpuRenderPipelineGetBindGroupLayout(g_pipelineState, 0);
+    bg_layouts[1] = wgpuRenderPipelineGetBindGroupLayout(g_pipelineState, 1);
+
+    WGPUBindGroupEntry common_bg_entries[] =
+    {
+        { nullptr, 0, g_resources.Uniforms, 0, sizeof(Uniforms), 0, 0 },
+        { nullptr, 1, 0, 0, 0, g_resources.Sampler, 0 },
+    };
+
+    WGPUBindGroupDescriptor common_bg_descriptor = {};
+    common_bg_descriptor.layout = bg_layouts[0];
+    common_bg_descriptor.entryCount = sizeof(common_bg_entries) / sizeof(WGPUBindGroupEntry);
+    common_bg_descriptor.entries = common_bg_entries;
+    g_resources.CommonBindGroup = wgpuDeviceCreateBindGroup(g_wgpuDevice, &common_bg_descriptor);
+
+    WGPUBindGroup image_bind_group = ImGui_ImplOffscreenWGPU_CreateImageBindGroup(bg_layouts[1], g_resources.FontTextureView);
+    g_resources.ImageBindGroup = image_bind_group;
+    g_resources.ImageBindGroupLayout = bg_layouts[1];
+    g_resources.ImageBindGroups.SetVoidPtr(ImHashData(&g_resources.FontTextureView, sizeof(ImTextureID)), image_bind_group);
+
+    SafeRelease(vertex_shader_desc.module);
+    SafeRelease(pixel_shader_desc.module);
+    SafeRelease(bg_layouts[0]);
+
+    return true;
+}
+
+void ImGui_ImplOffscreenWGPU_InvalidateDeviceObjects(void)
+{
+    if (!g_wgpuDevice)
+        return;
+
+    SafeRelease(g_pipelineState);
+    SafeRelease(g_resources);
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.Fonts->SetTexID(NULL); // We copied g_pFontTextureView to io.Fonts->TexID so let's clear that as well.
+
+    for (unsigned int i = 0; i < g_numFramesInFlight; i++)
+        SafeRelease(g_pFrameResources[i]);
+}
+
+bool ImGui_ImplOffscreenWGPU_Init(WGPUDevice device, int num_frames_in_flight, WGPUTextureFormat rt_format, const Config* config)
+{
+    g_config = *config;
+
+    // Setup backend capabilities flags
+    ImGuiIO& io = ImGui::GetIO();
+    io.BackendRendererName = "imgui_impl_webgpu";
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+
+    g_wgpuDevice = device;
+    g_defaultQueue = wgpuDeviceGetQueue(g_wgpuDevice);
+    g_renderTargetFormat = rt_format;
+    g_pFrameResources = new FrameResources[num_frames_in_flight];
+    g_numFramesInFlight = num_frames_in_flight;
+    g_frameIndex = UINT_MAX;
+
+    g_resources.FontTexture = NULL;
+    g_resources.FontTextureView = NULL;
+    g_resources.Sampler = NULL;
+    g_resources.Uniforms = NULL;
+    g_resources.CommonBindGroup = NULL;
+    g_resources.ImageBindGroups.Data.reserve(100);
+    g_resources.ImageBindGroup = NULL;
+    g_resources.ImageBindGroupLayout = NULL;
+
+    // Create buffers with a default size (they will later be grown as needed)
+    for (int i = 0; i < num_frames_in_flight; i++)
+    {
+        FrameResources* fr = &g_pFrameResources[i];
+        fr->IndexBuffer = NULL;
+        fr->VertexBuffer = NULL;
+        fr->IndexBufferHost = NULL;
+        fr->VertexBufferHost = NULL;
+        fr->IndexBufferSize = 10000;
+        fr->VertexBufferSize = 5000;
+    }
+
+    return true;
+}
+
+void ImGui_ImplOffscreenWGPU_Shutdown(void)
+{
+    // mziulek: Explicitly release the memory reserved in ImGui_ImplOffscreenWGPU_Init().
+    g_resources.ImageBindGroups.Clear();
+
+    ImGui_ImplOffscreenWGPU_InvalidateDeviceObjects();
+    delete[] g_pFrameResources;
+    g_pFrameResources = NULL;
+    wgpuQueueRelease(g_defaultQueue);
+    g_wgpuDevice = NULL;
+    g_numFramesInFlight = 0;
+    g_frameIndex = UINT_MAX;
+}
+
+void ImGui_ImplOffscreenWGPU_NewFrame(void)
+{
+    if (!g_pipelineState)
+        ImGui_ImplOffscreenWGPU_CreateDeviceObjects();
+}

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -488,6 +488,10 @@ pub const Condition = enum(u32) {
 pub const newFrame = zguiNewFrame;
 extern fn zguiNewFrame() void;
 //--------------------------------------------------------------------------------------------------
+/// `pub fn endFrame() void`
+pub const endFrame = zguiEndFrame;
+extern fn zguiEndFrame() void;
+//--------------------------------------------------------------------------------------------------
 /// `pub fn render() void`
 pub const render = zguiRender;
 extern fn zguiRender() void;
@@ -2597,6 +2601,8 @@ extern fn zguiEndListBox() void;
 // Item/Widgets Utilities and Query Functions
 //
 //--------------------------------------------------------------------------------------------------
+/// `pub fn setKeyboardFocusHere() void`
+pub const setKeyboardFocusHere = zguiSetKeyboardFocusHere;
 pub fn isItemHovered(flags: HoveredFlags) bool {
     return zguiIsItemHovered(flags);
 }
@@ -2629,6 +2635,7 @@ pub const isAnyItemHovered = zguiIsAnyItemHovered;
 pub const isAnyItemActive = zguiIsAnyItemActive;
 /// `pub fn isAnyItemFocused() bool`
 pub const isAnyItemFocused = zguiIsAnyItemFocused;
+extern fn zguiSetKeyboardFocusHere(offset: i32) void;
 extern fn zguiIsItemHovered(flags: HoveredFlags) bool;
 extern fn zguiIsItemActive() bool;
 extern fn zguiIsItemFocused() bool;

--- a/libs/zgui/src/main.zig
+++ b/libs/zgui/src/main.zig
@@ -9,3 +9,4 @@ pub const version = @import("std").SemanticVersion{ .major = 0, .minor = 9, .pat
 pub usingnamespace @import("gui.zig");
 pub const plot = @import("plot.zig");
 pub const backend = @import("backend_glfw_wgpu.zig");
+pub const offscreen = @import("offscreen_wgpu.zig");

--- a/libs/zgui/src/offscreen_wgpu.zig
+++ b/libs/zgui/src/offscreen_wgpu.zig
@@ -1,0 +1,57 @@
+const gui = @import("gui.zig");
+
+pub const TextureFilterMode = enum(u32) {
+    nearest,
+    linear,
+};
+
+pub const Config = extern struct {
+    pipeline_multisample_count: u32 = 1,
+    texture_filter_mode: TextureFilterMode = .linear,
+};
+
+// Those callbacks will chain-call user's previously installed callbacks, if any.
+// This means that custom user's callbacks need to be installed *before* calling zgpu.gui.init().
+pub fn initWithConfig(
+    wgpu_device: *const anyopaque, // wgpu.Device
+    wgpu_swap_chain_format: u32, // wgpu.TextureFormat
+    config: Config,
+) void {
+    if (!ImGui_ImplOffscreenWGPU_Init(wgpu_device, 1, wgpu_swap_chain_format, &config)) {
+        unreachable;
+    }
+}
+
+pub fn init(wgpu_device: *const anyopaque, wgpu_swap_chain_format: u32) void {
+    initWithConfig(wgpu_device, wgpu_swap_chain_format, .{});
+}
+
+pub fn deinit() void {
+    ImGui_ImplOffscreenWGPU_Shutdown();
+}
+
+pub fn newFrame(fb_width: u32, fb_height: u32) void {
+    ImGui_ImplOffscreenWGPU_NewFrame();
+
+    gui.io.setDisplaySize(@intToFloat(f32, fb_width), @intToFloat(f32, fb_height));
+    gui.io.setDisplayFramebufferScale(1.0, 1.0);
+
+    gui.newFrame();
+}
+
+pub fn draw(wgpu_render_pass: *const anyopaque) void {
+    gui.render();
+    ImGui_ImplOffscreenWGPU_RenderDrawData(gui.getDrawData(), wgpu_render_pass);
+}
+
+// Those functions are defined in 'imgui_impl_wgpu.cpp`
+// (they include few custom changes).
+extern fn ImGui_ImplOffscreenWGPU_Init(
+    device: *const anyopaque,
+    num_frames_in_flight: u32,
+    rt_format: u32,
+    config: *const Config,
+) bool;
+extern fn ImGui_ImplOffscreenWGPU_NewFrame() void;
+extern fn ImGui_ImplOffscreenWGPU_RenderDrawData(draw_data: *const anyopaque, pass_encoder: *const anyopaque) void;
+extern fn ImGui_ImplOffscreenWGPU_Shutdown() void;

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -956,6 +956,10 @@ ZGUI_API void zguiNewFrame(void) {
     ImGui::NewFrame();
 }
 
+ZGUI_API void zguiEndFrame(void) {
+    ImGui::EndFrame();
+}
+
 ZGUI_API void zguiRender(void) {
     ImGui::Render();
 }
@@ -1231,6 +1235,10 @@ ZGUI_API void zguiIoAddCharacterEvent(int c) {
 }
 
 
+ZGUI_API void zguiSetKeyboardFocusHere(int offset) {
+    return ImGui::SetKeyboardFocusHere(offset);
+}
+
 ZGUI_API bool zguiIsItemHovered(ImGuiHoveredFlags flags) {
     return ImGui::IsItemHovered(flags);
 }
@@ -1335,7 +1343,7 @@ ZGUI_API bool zguiBeginMenu(const char* label, bool enabled) {
 
 ZGUI_API void zguiEndMenu(void) {
     ImGui::EndMenu();
-} 
+}
 
 ZGUI_API bool zguiMenuItem(const char* label, const char* shortcut, bool selected, bool enabled) {
     return ImGui::MenuItem(label, shortcut, selected, enabled);

--- a/samples/text_transform_wgpu/README.md
+++ b/samples/text_transform_wgpu/README.md
@@ -1,0 +1,5 @@
+## text transform (wgpu)
+
+Demo of rendering zgui text into a texture to transform it.
+
+![image](screenshot.png)

--- a/samples/text_transform_wgpu/build.zig
+++ b/samples/text_transform_wgpu/build.zig
@@ -1,0 +1,47 @@
+const std = @import("std");
+const zgpu = @import("../../libs/zgpu/build.zig");
+const zmath = @import("../../libs/zmath/build.zig");
+const zpool = @import("../../libs/zpool/build.zig");
+const zglfw = @import("../../libs/zglfw/build.zig");
+const zgui = @import("../../libs/zgui/build.zig");
+
+const Options = @import("../../build.zig").Options;
+
+const demo_name = "text_transform_wgpu";
+const content_dir = demo_name ++ "_content/";
+
+pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
+    const exe = b.addExecutable(demo_name, thisDir() ++ "/src/" ++ demo_name ++ ".zig");
+
+    const exe_options = b.addOptions();
+    exe.addOptions("build_options", exe_options);
+    exe_options.addOption([]const u8, "content_dir", content_dir);
+
+    const install_content_step = b.addInstallDirectory(.{
+        .source_dir = thisDir() ++ "/" ++ content_dir,
+        .install_dir = .{ .custom = "" },
+        .install_subdir = "bin/" ++ content_dir,
+    });
+    exe.step.dependOn(&install_content_step.step);
+
+    exe.setBuildMode(options.build_mode);
+    exe.setTarget(options.target);
+
+    const zgpu_options = zgpu.BuildOptionsStep.init(b, .{});
+    const zgpu_pkg = zgpu.getPkg(&.{ zgpu_options.getPkg(), zpool.pkg, zglfw.pkg });
+
+    exe.addPackage(zgpu_pkg);
+    exe.addPackage(zgui.pkg);
+    exe.addPackage(zmath.pkg);
+    exe.addPackage(zglfw.pkg);
+
+    zgpu.link(exe, zgpu_options);
+    zglfw.link(exe);
+    zgui.link(exe);
+
+    return exe;
+}
+
+inline fn thisDir() []const u8 {
+    return comptime std.fs.path.dirname(@src().file) orelse ".";
+}

--- a/samples/text_transform_wgpu/screenshot.png
+++ b/samples/text_transform_wgpu/screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be3165ab5a4fd6d368882df8d34b8d1e282f2ff1282b7dcc0cdb259dc079e120
+size 90906

--- a/samples/text_transform_wgpu/src/text_transform_wgpu.zig
+++ b/samples/text_transform_wgpu/src/text_transform_wgpu.zig
@@ -78,11 +78,16 @@ const DemoState = struct {
 
     text_texture: zgpu.TextureHandle = .{},
     text_texture_view: zgpu.TextureViewHandle = .{},
-    text_texture_cache_key: [32]u8 = undefined,
+    text_texture_cache_key: struct {
+        text: [32]u8,
+        scaled_font: usize,
+    } = .{
+        .text = undefined,
+        .scaled_font = 0,
+    },
 
     sample_text: [32]u8 = [_]u8{0} ** 32,
-    render_scale: f32 = 1,
-    msaa: bool = false,
+    render_scale: i32 = 1,
     offset: [2]f32 = .{ 0, 0 },
     scale: f32 = 1,
     angle: f32 = 0,
@@ -91,29 +96,47 @@ const DemoState = struct {
     bind_group: zgpu.BindGroupHandle = .{},
     sampler: zgpu.SamplerHandle,
 
+    scaled_fonts: [6]zgui.Font,
+
     fn init(allocator: std.mem.Allocator, window: zglfw.Window) !DemoState {
         const gctx = try zgpu.GraphicsContext.create(allocator, window);
 
         zgui.init(allocator);
+
+        const screen_scale_factor = screen_scale_factor: {
+            const scale = window.getContentScale();
+            break :screen_scale_factor @max(scale[0], scale[1]);
+        };
         {
-            const scale_factor = scale_factor: {
-                const scale = window.getContentScale();
-                break :scale_factor math.max(scale[0], scale[1]);
-            };
+            zgui.useGlfw();
             _ = zgui.io.addFontFromFile(
                 content_dir ++ "Roboto-Medium.ttf",
-                math.floor(20.0 * scale_factor),
+                @floor(20.0 * screen_scale_factor),
             );
+            zgui.backend.init(window, gctx.device, @enumToInt(zgpu.GraphicsContext.swapchain_format));
         }
 
-        // This needs to be called *after* adding your custom fonts.
-        zgui.backend.init(window, gctx.device, @enumToInt(zgpu.GraphicsContext.swapchain_format));
+        zgui.initOffscreen();
+        var scaled_fonts: [6]zgui.Font = undefined;
+        {
+            zgui.useOffscreen();
+            var i: usize = 0;
+            while (i < scaled_fonts.len) : (i += 1) {
+                const render_scale = @intToFloat(f32, i + 1);
+                scaled_fonts[i] = zgui.io.addFontFromFile(
+                    content_dir ++ "Roboto-Medium.ttf",
+                    @floor(render_scale * 20.0 * screen_scale_factor),
+                );
+            }
+            zgui.offscreen.init(gctx.device, @enumToInt(zgpu.GraphicsContext.swapchain_format));
+        }
 
         const sampler = gctx.createSampler(.{ .min_filter = .linear });
 
         var demo = DemoState{
             .gctx = gctx,
             .sampler = sampler,
+            .scaled_fonts = scaled_fonts,
         };
 
         const default_text = "Sample";
@@ -124,6 +147,9 @@ const DemoState = struct {
 
     fn deinit(demo: *DemoState, allocator: std.mem.Allocator) void {
         const gctx = demo.gctx;
+        zgui.offscreen.deinit();
+        zgui.deinitOffscreen();
+
         zgui.backend.deinit();
         zgui.deinit();
         gctx.destroy(allocator);
@@ -132,104 +158,55 @@ const DemoState = struct {
     fn update(demo: *DemoState, _: std.mem.Allocator) !void {
         const gctx = demo.gctx;
 
-        if (!std.mem.eql(u8, &demo.text_texture_cache_key, &demo.sample_text)) {
-            demo.rerenderTextTexture();
-            std.mem.copy(u8, &demo.text_texture_cache_key, &demo.sample_text);
+        {
+            zgui.useGlfw();
+            zgui.backend.newFrame(
+                gctx.swapchain_descriptor.width,
+                gctx.swapchain_descriptor.height,
+            );
 
-            const bind_group_layout = gctx.createBindGroupLayout(&.{
-                zgpu.bufferEntry(0, .{ .vertex = true, .fragment = true }, .uniform, true, 0),
-                zgpu.samplerEntry(1, .{ .fragment = true }, .filtering),
-                zgpu.textureEntry(2, .{ .fragment = true }, .float, .tvdim_2d, false),
+            _ = zgui.begin("Controls", .{
+                .flags = .{
+                    .no_title_bar = true,
+                    .no_move = true,
+                    .no_collapse = true,
+                    .always_auto_resize = true,
+                },
             });
-            defer gctx.releaseResource(bind_group_layout);
+            defer zgui.end();
 
-            gctx.releaseResource(demo.bind_group);
-            demo.bind_group = gctx.createBindGroup(bind_group_layout, &.{
-                .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = 256 },
-                .{ .binding = 1, .sampler_handle = demo.sampler },
-                .{ .binding = 2, .texture_view_handle = demo.text_texture_view },
+            _ = zgui.inputText("Text", .{ .buf = &demo.sample_text });
+            _ = zgui.sliderInt("Render scale", .{
+                .v = &demo.render_scale,
+                .min = 1,
+                .max = 6,
+                .cfmt = "%dx",
             });
-
-            {
-                gctx.releaseResource(demo.pipeline);
-                const pipeline_layout = gctx.createPipelineLayout(&.{bind_group_layout});
-                defer gctx.releaseResource(pipeline_layout);
-
-                const vs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_vs, "vs");
-                defer vs_module.release();
-
-                const fs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_fs, "fs");
-                defer fs_module.release();
-
-                const color_targets = [_]wgpu.ColorTargetState{.{
-                    .format = zgpu.GraphicsContext.swapchain_format,
-                }};
-
-                // Create a render pipeline.
-                const pipeline_descriptor = wgpu.RenderPipelineDescriptor{
-                    .vertex = .{
-                        .module = vs_module,
-                        .entry_point = "main",
-                    },
-                    .primitive = .{
-                        .front_face = .ccw,
-                        .cull_mode = .back,
-                        .topology = .triangle_list,
-                    },
-                    .fragment = &.{
-                        .module = fs_module,
-                        .entry_point = "main",
-                        .target_count = color_targets.len,
-                        .targets = &color_targets,
-                    },
-                };
-                demo.pipeline = gctx.createRenderPipeline(pipeline_layout, pipeline_descriptor);
-            }
+            _ = zgui.sliderFloat2("Translate", .{
+                .v = &demo.offset,
+                .min = -500,
+                .max = 500,
+                .cfmt = "%.0f",
+            });
+            _ = zgui.sliderFloat("Scale", .{
+                .v = &demo.scale,
+                .min = 0.01,
+                .max = 20,
+                .cfmt = "%.2f",
+            });
+            _ = zgui.sliderAngle("Rotate", .{
+                .vrad = &demo.angle,
+                .deg_min = -180,
+                .deg_max = 180,
+            });
         }
 
-        zgui.backend.newFrame(
-            gctx.swapchain_descriptor.width,
-            gctx.swapchain_descriptor.height,
-        );
-
-        _ = zgui.begin("Controls", .{
-            .flags = .{
-                .no_title_bar = true,
-                .no_move = true,
-                .no_collapse = true,
-                .always_auto_resize = true,
-            },
-        });
-        defer zgui.end();
-
-        if (!zgui.isAnyItemActive()) {
-            zgui.setKeyboardFocusHere(0);
+        const scaled_font: usize = @intCast(usize, demo.render_scale - 1);
+        if (!std.mem.eql(u8, &demo.text_texture_cache_key.text, &demo.sample_text) or demo.text_texture_cache_key.scaled_font != scaled_font) {
+            demo.rerenderTextTexture(demo.scaled_fonts[scaled_font]);
+            std.mem.copy(u8, &demo.text_texture_cache_key.text, &demo.sample_text);
+            demo.text_texture_cache_key.scaled_font = scaled_font;
         }
-        _ = zgui.inputText("Text", .{ .buf = demo.sample_text[0..] });
-        _ = zgui.sliderFloat("Render scale", .{
-            .v = &demo.render_scale,
-            .min = 0.01,
-            .max = 8,
-            .cfmt = "%.2fx",
-        });
-        _ = zgui.checkbox("4x multisample anti-aliasing", .{ .v = &demo.msaa });
-        _ = zgui.sliderFloat2("Translate", .{
-            .v = &demo.offset,
-            .min = -500,
-            .max = 500,
-            .cfmt = "%.0f",
-        });
-        _ = zgui.sliderFloat("Scale", .{
-            .v = &demo.scale,
-            .min = 0.01,
-            .max = 20,
-            .cfmt = "%.2f x",
-        });
-        _ = zgui.sliderAngle("Rotate", .{
-            .vrad = &demo.angle,
-            .deg_min = -180,
-            .deg_max = 180,
-        });
     }
 
     fn draw(demo: *DemoState) void {
@@ -281,8 +258,8 @@ const DemoState = struct {
                                     zm.rotationZ(demo.angle),
                                     zm.mul(
                                         zm.scaling(
-                                            demo.scale,
-                                            demo.scale,
+                                            demo.scale / @intToFloat(f32, demo.render_scale),
+                                            demo.scale / @intToFloat(f32, demo.render_scale),
                                             1.0,
                                         ),
                                         zm.translation(
@@ -325,6 +302,7 @@ const DemoState = struct {
                     pass.release();
                 }
 
+                zgui.useGlfw();
                 zgui.backend.draw(pass);
             }
 
@@ -336,23 +314,28 @@ const DemoState = struct {
         _ = gctx.present();
     }
 
-    fn rerenderTextTexture(demo: *DemoState) void {
+    fn rerenderTextTexture(demo: *DemoState, scaled_font: zgui.Font) void {
         const gctx = demo.gctx;
 
-        zgui.backend.newFrame(
+        zgui.useOffscreen();
+        zgui.offscreen.newFrame(
             gctx.swapchain_descriptor.width,
             gctx.swapchain_descriptor.height,
         );
         const length = std.mem.indexOf(u8, &demo.sample_text, &[_]u8{0});
         const text = demo.sample_text[0 .. length orelse 32];
+
+        zgui.pushFont(scaled_font);
         const text_size = zgui.calcTextSize(text, .{});
+        zgui.popFont();
+
         const texture_size = .{
             .width = @floatToInt(u32, @ceil(text_size[0])),
             .height = @floatToInt(u32, @ceil(text_size[1])),
         };
         zgui.endFrame();
 
-        zgui.backend.newFrame(
+        zgui.offscreen.newFrame(
             texture_size.width,
             texture_size.height,
         );
@@ -387,7 +370,10 @@ const DemoState = struct {
                 },
             });
             defer zgui.end();
+
+            zgui.pushFont(scaled_font);
             zgui.textUnformatted(text);
+            zgui.popFont();
         }
 
         zgui.popStyleVar(.{
@@ -404,7 +390,6 @@ const DemoState = struct {
             .dimension = .tdim_2d,
             .size = texture_size,
             .format = gctx.swapchain_descriptor.format,
-            .sample_count = 1,
         });
         demo.text_texture_view = gctx.createTextureView(demo.text_texture, .{});
 
@@ -428,7 +413,7 @@ const DemoState = struct {
                     pass.release();
                 }
 
-                zgui.backend.draw(pass);
+                zgui.offscreen.draw(pass);
             }
 
             break :commands encoder.finish(null);
@@ -436,6 +421,56 @@ const DemoState = struct {
         defer commands.release();
 
         gctx.submit(&.{commands});
+
+        const bind_group_layout = gctx.createBindGroupLayout(&.{
+            zgpu.bufferEntry(0, .{ .vertex = true, .fragment = true }, .uniform, true, 0),
+            zgpu.samplerEntry(1, .{ .fragment = true }, .filtering),
+            zgpu.textureEntry(2, .{ .fragment = true }, .float, .tvdim_2d, false),
+        });
+        defer gctx.releaseResource(bind_group_layout);
+
+        gctx.releaseResource(demo.bind_group);
+        demo.bind_group = gctx.createBindGroup(bind_group_layout, &.{
+            .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = 256 },
+            .{ .binding = 1, .sampler_handle = demo.sampler },
+            .{ .binding = 2, .texture_view_handle = demo.text_texture_view },
+        });
+
+        {
+            gctx.releaseResource(demo.pipeline);
+            const pipeline_layout = gctx.createPipelineLayout(&.{bind_group_layout});
+            defer gctx.releaseResource(pipeline_layout);
+
+            const vs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_vs, "vs");
+            defer vs_module.release();
+
+            const fs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_fs, "fs");
+            defer fs_module.release();
+
+            const color_targets = [_]wgpu.ColorTargetState{.{
+                .format = zgpu.GraphicsContext.swapchain_format,
+            }};
+
+            // Create a render pipeline.
+            const pipeline_descriptor = wgpu.RenderPipelineDescriptor{
+                .vertex = .{
+                    .module = vs_module,
+                    .entry_point = "main",
+                },
+                .primitive = .{
+                    .front_face = .ccw,
+                    .cull_mode = .back,
+                    .topology = .triangle_list,
+                },
+                .fragment = &.{
+                    .module = fs_module,
+                    .entry_point = "main",
+                    .target_count = color_targets.len,
+                    .targets = &color_targets,
+                },
+            };
+            demo.pipeline = gctx.createRenderPipeline(pipeline_layout, pipeline_descriptor);
+        }
     }
 };
 
@@ -474,6 +509,7 @@ pub fn main() !void {
     defer demo.deinit(allocator);
 
     while (!window.shouldClose() and window.getKey(.escape) != .press) {
+        zgui.useGlfw();
         zglfw.pollEvents();
         try demo.update(allocator);
         demo.draw();

--- a/samples/text_transform_wgpu/src/text_transform_wgpu.zig
+++ b/samples/text_transform_wgpu/src/text_transform_wgpu.zig
@@ -10,11 +10,77 @@ const zm = @import("zmath");
 const content_dir = @import("build_options").content_dir;
 const window_title = "zig-gamedev: text transform(wgpu)";
 
+// zig fmt: off
+const wgsl_vs =
+\\  struct Uniforms {
+\\      aspect_ratio: f32,
+\\  }
+\\  @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+\\
+\\  struct Vertex {
+\\      @builtin(vertex_index) index : u32,
+\\  }
+\\
+\\  struct Fragment {
+\\      @builtin(position) position: vec4<f32>,
+\\      @location(0) uv: vec2<f32>,
+\\  }
+\\
+\\  @vertex
+\\  fn main(vertex: Vertex) -> Fragment {
+\\      var position = array<vec2<f32>, 6>(
+\\          vec2<f32>(-0.25,  0.25),
+\\          vec2<f32>(-0.25, -0.25),
+\\          vec2<f32>( 0.25, -0.25),
+\\          vec2<f32>(-0.25,  0.25),
+\\          vec2<f32>( 0.25, -0.25),
+\\          vec2<f32>( 0.25,  0.25),
+\\      );
+\\      var uv = array<vec2<f32>, 6>(
+\\          vec2<f32>(0.0, 0.0),
+\\          vec2<f32>(0.0, 1.0),
+\\          vec2<f32>(1.0, 1.0),
+\\          vec2<f32>(0.0, 0.0),
+\\          vec2<f32>(1.0, 1.0),
+\\          vec2<f32>(1.0, 0.0),
+\\      );
+\\      var fragment: Fragment;
+\\      fragment.position = vec4<f32>(position[vertex.index].x / uniforms.aspect_ratio, position[vertex.index].y, 0.0, 1.0);
+\\      fragment.uv = uv[vertex.index];
+\\      return fragment;
+\\  }
+;
+const wgsl_fs =
+\\  @group(0) @binding(1) var text_sampler: sampler;
+\\  @group(0) @binding(2) var text_texture: texture_2d<f32>;
+\\
+\\  struct Fragment {
+\\      @location(0) uv: vec2<f32>,
+\\  }
+\\
+\\  struct Screen {
+\\      @location(0) color: vec4<f32>,
+\\  }
+\\
+\\  @fragment
+\\  fn main(fragment: Fragment) -> Screen {
+\\      var screen: Screen;
+\\      screen.color = textureSampleLevel(text_texture, text_sampler, fragment.uv, 1.0);
+\\      return screen;
+\\  }
+// zig fmt: on
+;
+
+const Uniforms = extern struct {
+    aspect_ratio: f32,
+};
+
 const DemoState = struct {
     gctx: *zgpu.GraphicsContext,
 
-    text_texture: zgpu.TextureHandle,
-    text_texture_cache_key: []u8 = "",
+    text_texture: zgpu.TextureHandle = .{},
+    text_texture_view: zgpu.TextureViewHandle = .{},
+    text_texture_cache_key: [32]u8 = undefined,
 
     sample_text: [32]u8 = [_]u8{0} ** 32,
     render_scale: f32 = 1,
@@ -22,6 +88,10 @@ const DemoState = struct {
     offset: [2]f32 = .{ 0, 0 },
     scale: [2]f32 = .{ 1, 1 },
     angle: f32 = 0,
+
+    pipeline: zgpu.RenderPipelineHandle = .{},
+    bind_group: zgpu.BindGroupHandle = .{},
+    sampler: zgpu.SamplerHandle,
 
     fn init(allocator: std.mem.Allocator, window: zglfw.Window) !DemoState {
         const gctx = try zgpu.GraphicsContext.create(allocator, window);
@@ -50,13 +120,15 @@ const DemoState = struct {
         // This needs to be called *after* adding your custom fonts.
         zgui.backend.init(window, gctx.device, @enumToInt(zgpu.GraphicsContext.swapchain_format));
 
+        const sampler = gctx.createSampler(.{});
+
         var demo = DemoState{
             .gctx = gctx,
-            .text_texture = .{},
+            .sampler = sampler,
         };
 
         const default_text = "Greetings!";
-        std.mem.copy(u8, demo.sample_text[0..], default_text);
+        std.mem.copy(u8, &demo.sample_text, default_text);
 
         return demo;
     }
@@ -71,15 +143,66 @@ const DemoState = struct {
     fn update(demo: *DemoState, _: std.mem.Allocator) !void {
         const gctx = demo.gctx;
 
+        if (!std.mem.eql(u8, &demo.text_texture_cache_key, &demo.sample_text)) {
+            demo.rerenderTextTexture();
+            std.mem.copy(u8, &demo.text_texture_cache_key, &demo.sample_text);
+
+            const bind_group_layout = gctx.createBindGroupLayout(&.{
+                zgpu.bufferEntry(0, .{ .vertex = true, .fragment = true }, .uniform, true, 0),
+                zgpu.samplerEntry(1, .{ .fragment = true }, .filtering),
+                zgpu.textureEntry(2, .{ .fragment = true }, .float, .tvdim_2d, false),
+            });
+            defer gctx.releaseResource(bind_group_layout);
+
+            gctx.releaseResource(demo.bind_group);
+            demo.bind_group = gctx.createBindGroup(bind_group_layout, &.{
+                .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = 256 },
+                .{ .binding = 1, .sampler_handle = demo.sampler },
+                .{ .binding = 2, .texture_view_handle = demo.text_texture_view },
+            });
+
+            {
+                gctx.releaseResource(demo.pipeline);
+                const pipeline_layout = gctx.createPipelineLayout(&.{bind_group_layout});
+                defer gctx.releaseResource(pipeline_layout);
+
+                const vs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_vs, "vs");
+                defer vs_module.release();
+
+                const fs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_fs, "fs");
+                defer fs_module.release();
+
+                const color_targets = [_]wgpu.ColorTargetState{.{
+                    .format = zgpu.GraphicsContext.swapchain_format,
+                }};
+
+                // Create a render pipeline.
+                const pipeline_descriptor = wgpu.RenderPipelineDescriptor{
+                    .vertex = .{
+                        .module = vs_module,
+                        .entry_point = "main",
+                    },
+                    .primitive = .{
+                        .front_face = .ccw,
+                        .cull_mode = .back,
+                        .topology = .triangle_list,
+                    },
+                    .fragment = &.{
+                        .module = fs_module,
+                        .entry_point = "main",
+                        .target_count = color_targets.len,
+                        .targets = &color_targets,
+                    },
+                };
+                demo.pipeline = gctx.createRenderPipeline(pipeline_layout, pipeline_descriptor);
+            }
+        }
+
         zgui.backend.newFrame(
             gctx.swapchain_descriptor.width,
             gctx.swapchain_descriptor.height,
         );
 
-        if (!std.mem.eql(u8, demo.text_texture_cache_key, demo.sample_text[0..])) {
-            demo.recreateTextTexture();
-            demo.text_texture_cache_key = demo.sample_text[0..];
-        }
         _ = zgui.begin("Controls", .{
             .flags = .{
                 .no_title_bar = true,
@@ -90,6 +213,9 @@ const DemoState = struct {
         });
         defer zgui.end();
 
+        if (!zgui.isAnyItemActive()) {
+            zgui.setKeyboardFocusHere(0);
+        }
         _ = zgui.inputText("Sample text", .{ .buf = demo.sample_text[0..] });
         _ = zgui.sliderFloat("Render scale", .{
             .v = &demo.render_scale,
@@ -129,6 +255,35 @@ const DemoState = struct {
             defer encoder.release();
 
             {
+                const text_texture_info = gctx.lookupResourceInfo(demo.text_texture).?;
+                const pipeline = gctx.lookupResource(demo.pipeline).?;
+                const bind_group = gctx.lookupResource(demo.bind_group).?;
+                const color_attachments = [_]wgpu.RenderPassColorAttachment{.{
+                    .view = back_buffer_view,
+                    .load_op = .clear,
+                    .store_op = .store,
+                }};
+                const render_pass_info = wgpu.RenderPassDescriptor{
+                    .color_attachment_count = color_attachments.len,
+                    .color_attachments = &color_attachments,
+                };
+                const pass = encoder.beginRenderPass(render_pass_info);
+                defer {
+                    pass.end();
+                    pass.release();
+                }
+                pass.setPipeline(pipeline);
+                const screen_aspect_ratio = @intToFloat(f32, gctx.swapchain_descriptor.width) / @intToFloat(f32, gctx.swapchain_descriptor.height);
+                const texture_aspect_ratio = @intToFloat(f32, text_texture_info.size.width) / @intToFloat(f32, text_texture_info.size.height);
+                const mem = gctx.uniformsAllocate(Uniforms, 1);
+                mem.slice[0] = .{
+                    .aspect_ratio = screen_aspect_ratio / texture_aspect_ratio,
+                };
+                pass.setBindGroup(0, bind_group, &.{mem.offset});
+                pass.draw(6, 1, 0, 0);
+            }
+
+            {
                 const color_attachments = [_]wgpu.RenderPassColorAttachment{.{
                     .view = back_buffer_view,
                     .load_op = .load,
@@ -155,21 +310,106 @@ const DemoState = struct {
         _ = gctx.present();
     }
 
-    fn recreateTextTexture(demo: *DemoState) void {
+    fn rerenderTextTexture(demo: *DemoState) void {
         const gctx = demo.gctx;
-        gctx.releaseResource(demo.text_texture);
 
-        const text_size = zgui.calcTextSize(demo.sample_text[0..], .{});
+        zgui.backend.newFrame(
+            gctx.swapchain_descriptor.width,
+            gctx.swapchain_descriptor.height,
+        );
+        const length = std.mem.indexOf(u8, &demo.sample_text, &[_]u8{0});
+        const text = demo.sample_text[0 .. length orelse 32];
+        const text_size = zgui.calcTextSize(text, .{});
+        const texture_size = .{
+            .width = @floatToInt(u32, @ceil(text_size[0])),
+            .height = @floatToInt(u32, @ceil(text_size[1])),
+        };
+        zgui.endFrame();
+
+        zgui.backend.newFrame(
+            texture_size.width,
+            texture_size.height,
+        );
+        zgui.pushStyleVar2f(.{
+            .idx = .window_padding,
+            .v = .{ 0, 0 },
+        });
+        zgui.pushStyleVar1f(.{
+            .idx = .window_border_size,
+            .v = 0,
+        });
+        zgui.pushStyleVar2f(.{
+            .idx = .frame_padding,
+            .v = .{ 0, 0 },
+        });
+        zgui.pushStyleVar1f(.{
+            .idx = .frame_border_size,
+            .v = 0,
+        });
+        {
+            zgui.setNextWindowPos(.{ .x = 0, .y = 0 });
+            zgui.setNextWindowSize(.{
+                .w = @intToFloat(f32, texture_size.width),
+                .h = @intToFloat(f32, texture_size.height),
+            });
+            _ = zgui.begin("Text", .{
+                .flags = .{
+                    .no_title_bar = true,
+                    .no_resize = true,
+                    .no_move = true,
+                    .no_collapse = true,
+                },
+            });
+            defer zgui.end();
+            zgui.textUnformatted(text);
+        }
+
+        zgui.popStyleVar(.{
+            .count = 4,
+        });
+
+        gctx.releaseResource(demo.text_texture_view);
+        gctx.destroyResource(demo.text_texture);
         demo.text_texture = gctx.createTexture(.{
-            .usage = .{ .render_attachment = true },
-            .dimension = .tdim_2d,
-            .size = .{
-                .width = @floatToInt(u32, @ceil(text_size[0])),
-                .height = @floatToInt(u32, @ceil(text_size[1])),
+            .usage = .{
+                .texture_binding = true,
+                .render_attachment = true,
             },
+            .dimension = .tdim_2d,
+            .size = texture_size,
             .format = gctx.swapchain_descriptor.format,
             .sample_count = 1,
         });
+        demo.text_texture_view = gctx.createTextureView(demo.text_texture, .{});
+
+        const commands = commands: {
+            const encoder = gctx.device.createCommandEncoder(null);
+            defer encoder.release();
+
+            {
+                const color_attachments = [_]wgpu.RenderPassColorAttachment{.{
+                    .view = gctx.lookupResource(demo.text_texture_view).?,
+                    .load_op = .load,
+                    .store_op = .store,
+                }};
+                const render_pass_info = wgpu.RenderPassDescriptor{
+                    .color_attachment_count = color_attachments.len,
+                    .color_attachments = &color_attachments,
+                };
+                const pass = encoder.beginRenderPass(render_pass_info);
+                defer {
+                    pass.end();
+                    pass.release();
+                }
+
+                zgui.backend.draw(pass);
+            }
+
+            break :commands encoder.finish(null);
+        };
+        defer commands.release();
+
+        gctx.submit(&.{commands});
     }
 };
 

--- a/samples/text_transform_wgpu/src/text_transform_wgpu.zig
+++ b/samples/text_transform_wgpu/src/text_transform_wgpu.zig
@@ -1,0 +1,215 @@
+const std = @import("std");
+const math = std.math;
+const assert = std.debug.assert;
+const zglfw = @import("zglfw");
+const zgpu = @import("zgpu");
+const wgpu = zgpu.wgpu;
+const zgui = @import("zgui");
+const zm = @import("zmath");
+
+const content_dir = @import("build_options").content_dir;
+const window_title = "zig-gamedev: text transform(wgpu)";
+
+const DemoState = struct {
+    gctx: *zgpu.GraphicsContext,
+
+    text_texture: zgpu.TextureHandle,
+    text_texture_cache_key: []u8 = "",
+
+    sample_text: [32]u8 = [_]u8{0} ** 32,
+    render_scale: f32 = 1,
+    msaa: bool = false,
+    offset: [2]f32 = .{ 0, 0 },
+    scale: [2]f32 = .{ 1, 1 },
+    angle: f32 = 0,
+
+    fn init(allocator: std.mem.Allocator, window: zglfw.Window) !DemoState {
+        const gctx = try zgpu.GraphicsContext.create(allocator, window);
+
+        zgui.init(allocator);
+        const scale_factor = scale_factor: {
+            const scale = window.getContentScale();
+            break :scale_factor math.max(scale[0], scale[1]);
+        };
+        _ = zgui.io.addFontFromFile(
+            content_dir ++ "Roboto-Medium.ttf",
+            math.floor(20.0 * scale_factor),
+        );
+        {
+            var config = zgui.FontConfig.init();
+            config.merge_mode = true;
+            const ranges: []const u16 = &.{ 0x02DA, 0x02DB, 0 };
+            _ = zgui.io.addFontFromFileWithConfig(
+                content_dir ++ "Roboto-Medium.ttf",
+                math.floor(20.0 * scale_factor),
+                config,
+                ranges.ptr,
+            );
+        }
+
+        // This needs to be called *after* adding your custom fonts.
+        zgui.backend.init(window, gctx.device, @enumToInt(zgpu.GraphicsContext.swapchain_format));
+
+        var demo = DemoState{
+            .gctx = gctx,
+            .text_texture = .{},
+        };
+
+        const default_text = "Greetings!";
+        std.mem.copy(u8, demo.sample_text[0..], default_text);
+
+        return demo;
+    }
+
+    fn deinit(demo: *DemoState, allocator: std.mem.Allocator) void {
+        const gctx = demo.gctx;
+        zgui.backend.deinit();
+        zgui.deinit();
+        gctx.destroy(allocator);
+    }
+
+    fn update(demo: *DemoState, _: std.mem.Allocator) !void {
+        const gctx = demo.gctx;
+
+        zgui.backend.newFrame(
+            gctx.swapchain_descriptor.width,
+            gctx.swapchain_descriptor.height,
+        );
+
+        if (!std.mem.eql(u8, demo.text_texture_cache_key, demo.sample_text[0..])) {
+            demo.recreateTextTexture();
+            demo.text_texture_cache_key = demo.sample_text[0..];
+        }
+        _ = zgui.begin("Controls", .{
+            .flags = .{
+                .no_title_bar = true,
+                .no_move = true,
+                .no_collapse = true,
+                .always_auto_resize = true,
+            },
+        });
+        defer zgui.end();
+
+        _ = zgui.inputText("Sample text", .{ .buf = demo.sample_text[0..] });
+        _ = zgui.sliderFloat("Render scale", .{
+            .v = &demo.render_scale,
+            .min = 0.01,
+            .max = 8,
+            .cfmt = "%.2fx",
+        });
+        _ = zgui.checkbox("4x multisample anti-aliasing", .{ .v = &demo.msaa });
+        _ = zgui.sliderFloat2("Translate", .{
+            .v = &demo.offset,
+            .min = -1000,
+            .max = 1000,
+            .cfmt = "%.0f",
+        });
+        _ = zgui.sliderFloat2("Scale", .{
+            .v = &demo.scale,
+            .min = -2,
+            .max = 2,
+            .cfmt = "%.2f x",
+        });
+        _ = zgui.sliderFloat("Rotate", .{
+            .v = &demo.angle,
+            .min = 0,
+            .max = 360,
+            .cfmt = "%.0f˚",
+        });
+    }
+
+    fn draw(demo: *DemoState) void {
+        const gctx = demo.gctx;
+
+        const back_buffer_view = gctx.swapchain.getCurrentTextureView();
+        defer back_buffer_view.release();
+
+        const commands = commands: {
+            const encoder = gctx.device.createCommandEncoder(null);
+            defer encoder.release();
+
+            {
+                const color_attachments = [_]wgpu.RenderPassColorAttachment{.{
+                    .view = back_buffer_view,
+                    .load_op = .load,
+                    .store_op = .store,
+                }};
+                const render_pass_info = wgpu.RenderPassDescriptor{
+                    .color_attachment_count = color_attachments.len,
+                    .color_attachments = &color_attachments,
+                };
+                const pass = encoder.beginRenderPass(render_pass_info);
+                defer {
+                    pass.end();
+                    pass.release();
+                }
+
+                zgui.backend.draw(pass);
+            }
+
+            break :commands encoder.finish(null);
+        };
+        defer commands.release();
+
+        gctx.submit(&.{commands});
+        _ = gctx.present();
+    }
+
+    fn recreateTextTexture(demo: *DemoState) void {
+        const gctx = demo.gctx;
+        gctx.releaseResource(demo.text_texture);
+
+        const text_size = zgui.calcTextSize(demo.sample_text[0..], .{});
+        demo.text_texture = gctx.createTexture(.{
+            .usage = .{ .render_attachment = true },
+            .dimension = .tdim_2d,
+            .size = .{
+                .width = @floatToInt(u32, @ceil(text_size[0])),
+                .height = @floatToInt(u32, @ceil(text_size[1])),
+            },
+            .format = gctx.swapchain_descriptor.format,
+            .sample_count = 1,
+        });
+    }
+};
+
+pub fn main() !void {
+    zglfw.init() catch {
+        std.log.err("Failed to initialize GLFW library.", .{});
+        return;
+    };
+    defer zglfw.terminate();
+
+    // Change current working directory to where the executable is located.
+    {
+        var buffer: [1024]u8 = undefined;
+        const path = std.fs.selfExeDirPath(buffer[0..]) catch ".";
+        std.os.chdir(path) catch {};
+    }
+
+    zglfw.defaultWindowHints();
+    zglfw.windowHint(.cocoa_retina_framebuffer, 1);
+    zglfw.windowHint(.client_api, 0);
+    const window = zglfw.createWindow(1600, 1000, window_title, null, null) catch {
+        std.log.err("Failed to create demo window.", .{});
+        return;
+    };
+    defer window.destroy();
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const allocator = gpa.allocator();
+
+    var demo = DemoState.init(allocator, window) catch {
+        std.log.err("Failed to initialize the demo.", .{});
+        return;
+    };
+    defer demo.deinit(allocator);
+
+    while (!window.shouldClose() and window.getKey(.escape) != .press) {
+        zglfw.pollEvents();
+        try demo.update(allocator);
+        demo.draw();
+    }
+}

--- a/samples/text_transform_wgpu/text_transform_wgpu_content/Roboto-Medium.ttf
+++ b/samples/text_transform_wgpu/text_transform_wgpu_content/Roboto-Medium.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559132c89ad51d8a2ba5b171887a44a7ba93776e205f553573de228e64b45f8
+size 162588


### PR DESCRIPTION
Discussed in https://github.com/michal-z/zig-gamedev/issues/95, here is the implementation of offscreen zgui text to texture and transformation.

I ran into quite a few issues and looking for a better design.

Issues:

1. Initially I interleaved `zgui.backend.newFrame` for the main UI and the offscreen, but this breaks imgui as it keeps track of data between frames in order for the text input and mouse drag focus to work. The solution to this is to create a second imgui context and switch between them.
2. Creating a second context for imgui was easy enough but `zgui.backend.init` assumes the backend is glfw, which the second context is not. The solution was to duplicate `backend_glfw_wgpu.zig` to `offscreen_wgpu.zig`
3. The next problem was both were relying on the same `imgui_impl_wgpu.cpp` which held static data. The solution to that was to duplicate `imgui_impl_wgpu.cpp` to `imgui_impl_offscreen_wgpu.cpp`

I added the ability to switch between the glfw and offscreen context with `useGlfw` and `useOffscreen`. I maintained backwards compatibility as by default `useGlfw` is implied. But once the offscreen context is enabled, things like` zglfw.pollEvents` need to be prefixed with `useGlfw`

As per trying out this process from last time:
- [x] Create strawman api/implementation and sample using it
- [ ] Debate strawman to decide on better api/implementation design
- [ ] Execute on better api/implementation design
- [ ] Last review to nitpick final details such as code conventions and better types