### PR TITLE
zgui: exposed popup modal api

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -2748,6 +2748,34 @@ pub const beginTooltip = zguiBeginTooltip;
 pub const endTooltip = zguiEndTooltip;
 extern fn zguiBeginTooltip() void;
 extern fn zguiEndTooltip() void;
+
+pub const PopupFlags = packed struct(u32) {
+    mouse_button_left: bool = false,
+    mouse_button_right: bool = false,
+    mouse_button_middle: bool = false,
+    mouse_button_mask_: bool = false,
+    mouse_button_default_: bool = false,
+    no_open_over_existing_popup: bool = false,
+    no_open_over_items: bool = false,
+    any_popup_id: bool = false,
+    any_popup_level: bool = false,
+    any_popup: bool = false,
+    _padding: u22 = 0,
+};
+pub fn beginPopupModal(name: [:0]const u8, args: Begin) bool {
+    return zguiBeginPopupModal(name, args.popen, args.flags);
+}
+pub fn openPopup(str_id: [:0]const u8, flags: PopupFlags) void {
+    zguiOpenPopup(str_id, flags);
+}
+/// `pub fn endPopup() void`
+pub const endPopup = zguiEndPopup;
+/// `pub fn closeCurrentPopup() void`
+pub const closeCurrentPopup = zguiCloseCurrentPopup;
+extern fn zguiBeginPopupModal(name: [*:0]const u8, popen: ?*bool, flags: WindowFlags) bool;
+extern fn zguiEndPopup() void;
+extern fn zguiOpenPopup(str_id: [*:0]const u8, flags: PopupFlags) void;
+extern fn zguiCloseCurrentPopup() void;
 //--------------------------------------------------------------------------------------------------
 //
 // Tabs

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -2838,6 +2838,20 @@ extern fn zguiSetTabItemClosed(tab_or_docked_window_label: [*:0]const u8) void;
 //
 //--------------------------------------------------------------------------------------------------
 pub const Viewport = *opaque {
+    pub fn getPos(viewport: Viewport) [2]f32 {
+        var pos: [2]f32 = undefined;
+        zguiViewport_GetPos(viewport, &pos);
+        return pos;
+    }
+    extern fn zguiViewport_GetPos(viewport: Viewport, pos: *[2]f32) void;
+
+    pub fn getSize(viewport: Viewport) [2]f32 {
+        var pos: [2]f32 = undefined;
+        zguiViewport_GetSize(viewport, &pos);
+        return pos;
+    }
+    extern fn zguiViewport_GetSize(viewport: Viewport, size: *[2]f32) void;
+
     pub fn getWorkPos(viewport: Viewport) [2]f32 {
         var pos: [2]f32 = undefined;
         zguiViewport_GetWorkPos(viewport, &pos);
@@ -2851,6 +2865,24 @@ pub const Viewport = *opaque {
         return pos;
     }
     extern fn zguiViewport_GetWorkSize(viewport: Viewport, size: *[2]f32) void;
+
+    pub fn getCenter(viewport: Viewport) [2]f32 {
+        const pos = viewport.getPos();
+        const size = viewport.getSize();
+        return .{
+            pos[0] + size[0] * 0.5,
+            pos[1] + size[1] * 0.5,
+        };
+    }
+
+    pub fn getWorkCenter(viewport: Viewport) [2]f32 {
+        const pos = viewport.getWorkPos();
+        const size = viewport.getWorkSize();
+        return .{
+            pos[0] + size[0] * 0.5,
+            pos[1] + size[1] * 0.5,
+        };
+    }
 };
 pub const getMainViewport = zguiGetMainViewport;
 extern fn zguiGetMainViewport() Viewport;

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1372,6 +1372,22 @@ ZGUI_API void zguiBeginTooltip(void) {
 ZGUI_API void zguiEndTooltip(void) {
     ImGui::EndTooltip();
 }
+
+ZGUI_API bool zguiBeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags flags) {
+    return ImGui::BeginPopupModal(name, p_open, flags);
+}
+
+ZGUI_API void zguiEndPopup(void) {
+    ImGui::EndPopup();
+}
+
+ZGUI_API void zguiOpenPopup(const char* str_id, ImGuiPopupFlags popup_flags) {
+    ImGui::OpenPopup(str_id, popup_flags);
+}
+
+ZGUI_API void zguiCloseCurrentPopup(void) {
+    ImGui::CloseCurrentPopup();
+}
 //--------------------------------------------------------------------------------------------------
 //
 // DrawList

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1815,6 +1815,18 @@ ZGUI_API ImGuiViewport* zguiGetMainViewport(void) {
     return ImGui::GetMainViewport();
 }
 
+ZGUI_API void zguiViewport_GetPos(ImGuiViewport* viewport, float p[2]) {
+    const ImVec2 pos = viewport->Pos;
+    p[0] = pos.x;
+    p[1] = pos.y;
+}
+
+ZGUI_API void zguiViewport_GetSize(ImGuiViewport* viewport, float p[2]) {
+    const ImVec2 sz = viewport->Size;
+    p[0] = sz.x;
+    p[1] = sz.y;
+}
+
 ZGUI_API void zguiViewport_GetWorkPos(ImGuiViewport* viewport, float p[2]) {
     const ImVec2 pos = viewport->WorkPos;
     p[0] = pos.x;


### PR DESCRIPTION
Added:

- `ImGui::BeginPopupModal`
- `ImGui::EndPopup`
- `ImGui::OpenPopup`
- `ImGui::CloseCurrentPopup`
- `viewport->Pos`
- `viewport->Size`

Enables:
```zig
if (zgui.button("Open modal")) {
    zgui.openPopup("Modal title/id", .{});
}

{
    const center = zgui.getMainViewport().getCenter();
    zgui.setNextWindowPos(.{
        .x = center[0],
        .y = center[1],
        .cond = .appearing,
        .pivot_x = 0.5,
        .pivot_y = 0.5,
    });
}
if (zgui.beginPopupModal("Modal title/id", .{})) {
    if (zgui.button("Close modal", .{})) {
        zgui.closeCurrentPopup();
    }
    zgui.endPopup();
}
```