### PR TITLE
allow imgui.ini to be disabled

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -164,10 +164,10 @@ pub const io = struct {
     pub const getWantCaptureKeyboard = zguiIoGetWantCaptureKeyboard;
     extern fn zguiIoGetWantCaptureKeyboard() bool;
 
-    pub fn setIniFilename(filename: [:0]const u8) void {
+    pub fn setIniFilename(filename: ?[*:0]const u8) void {
         zguiIoSetIniFilename(filename);
     }
-    extern fn zguiIoSetIniFilename(filename: [*:0]const u8) void;
+    extern fn zguiIoSetIniFilename(filename: ?[*:0]const u8) void;
 
     /// `pub fn setDisplaySize(width: f32, height: f32) void`
     pub const setDisplaySize = zguiIoSetDisplaySize;


### PR DESCRIPTION
[Learned that setting `io.IniFilename` to `NULL` will disable `imgui.ini`](https://www.reddit.com/r/imgui/comments/4xstmx/comment/d6jjtlh/?utm_source=reddit&utm_medium=web2x&context=3).

Implemented this by making `zgui.io.setIniFilename` parameter optional.