### PR TITLE
Get Glfw Window Attributes

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -456,6 +456,14 @@ pub const Window = opaque {
         hovered = 0x0002000B,
         focus_on_show = 0x0002000C,
     };
+    pub fn getAttribute(window: *Window, attrib: Attribute) bool {
+        if (glfwGetWindowAttrib(window, @enumToInt(attrib)) == 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+    extern fn glfwGetWindowAttrib(window: *Window, attrib: i32) u32;
 
     pub const Hint = enum(i32) {
         client_api = 0x00022001,
@@ -522,15 +530,6 @@ pub const Window = opaque {
         return .{ width, height };
     }
     extern fn glfwGetWindowSize(window: *Window, width: *i32, height: *i32) void;
-
-    pub fn getAttribute(window: *Window, attrib: Attribute) bool {
-        if (glfwGetWindowAttrib(window, @enumToInt(attrib)) == 0) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-    extern fn glfwGetWindowAttrib(window: *Window, attrib: i32) u32;
 
     /// `pub fn setKeyCallback(window: *Window, callback) void`
     pub const setKeyCallback = glfwSetKeyCallback;

--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -442,6 +442,21 @@ pub const Monitor = opaque {
 //
 //--------------------------------------------------------------------------------------------------
 pub const Window = opaque {
+    pub const Attribute = enum(i32) {
+        focused = 0x00020001,
+        iconified = 0x00020002,
+        resizable = 0x00020003,
+        visible = 0x00020004,
+        decorated = 0x00020005,
+        auto_iconify = 0x00020006,
+        floating = 0x00020007,
+        maximized = 0x00020008,
+        center_cursor = 0x00020009,
+        transparent_framebuffer = 0x0002000A,
+        hovered = 0x0002000B,
+        focus_on_show = 0x0002000C,
+    };
+
     pub const Hint = enum(i32) {
         client_api = 0x00022001,
         cocoa_retina_framebuffer = 0x00023001,
@@ -507,6 +522,15 @@ pub const Window = opaque {
         return .{ width, height };
     }
     extern fn glfwGetWindowSize(window: *Window, width: *i32, height: *i32) void;
+
+    pub fn getAttribute(window: *Window, attrib: Attribute) bool {
+        if (glfwGetWindowAttrib(window, @enumToInt(attrib)) == 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+    extern fn glfwGetWindowAttrib(window: *Window, attrib: i32) u32;
 
     /// `pub fn setKeyCallback(window: *Window, callback) void`
     pub const setKeyCallback = glfwSetKeyCallback;


### PR DESCRIPTION
Code for getting glfw window attributes.

I use it for checking if window is focused. My main function looks like
```
while (!window.shouldClose()) {
        zglfw.pollEvents();
        if (!window.getAttribute(zglfw.Window.Attribute.focused)) {
            continue;
        }
        update(&demo);
        draw(&demo);
}
```
I'm not sure if this is how you want it implemented, so feel free to rewrite.

I also saw a glfwSetWindowFocusCallback should we have both?