### PR TITLE
zmesh: remove assert in remapVertexBuffer

### DIFF
--- a/libs/zmesh/src/zmeshoptimizer.zig
+++ b/libs/zmesh/src/zmeshoptimizer.zig
@@ -26,7 +26,6 @@ pub inline fn remapVertexBuffer(
     vertices: []const T,
     remap: []const u32,
 ) void {
-    assert(destination.len >= vertices.len);
     meshopt_remapVertexBuffer(
         destination.ptr,
         vertices.ptr,


### PR DESCRIPTION
_remapVertexBuffer_ incorrectly asserted that destination slice was bigger than source. It will pack vertices in a smaller destination
slice.