### PR TITLE
Make upload_heap_capacity a build option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,11 @@ pub fn build(b: *std.build.Builder) void {
             "zd3d12-enable-gbv",
             "Enable DirectX 12 GPU-Based Validation (GBV)",
         ) orelse false,
+        .zd3d12_upload_heap_capacity = b.option(
+            u32,
+            "zd3d12-upload-heap-capacity",
+            "DirectX 12 Upload Heap Capacity",
+        ) orelse 24 * 1024 * 1024,
         .zpix_enable = b.option(bool, "zpix-enable", "Enable PIX for Windows profiler") orelse false,
     };
     ensureTarget(options.target) catch return;
@@ -172,6 +177,7 @@ pub const Options = struct {
 
     zd3d12_enable_debug_layer: bool,
     zd3d12_enable_gbv: bool,
+    zd3d12_upload_heap_capacity: u32,
 
     zpix_enable: bool,
 };

--- a/build.zig
+++ b/build.zig
@@ -18,11 +18,6 @@ pub fn build(b: *std.build.Builder) void {
             "zd3d12-enable-gbv",
             "Enable DirectX 12 GPU-Based Validation (GBV)",
         ) orelse false,
-        .zd3d12_upload_heap_capacity = b.option(
-            u32,
-            "zd3d12-upload-heap-capacity",
-            "DirectX 12 Upload Heap Capacity",
-        ) orelse 24 * 1024 * 1024,
         .zpix_enable = b.option(bool, "zpix-enable", "Enable PIX for Windows profiler") orelse false,
     };
     ensureTarget(options.target) catch return;
@@ -177,7 +172,6 @@ pub const Options = struct {
 
     zd3d12_enable_debug_layer: bool,
     zd3d12_enable_gbv: bool,
-    zd3d12_upload_heap_capacity: u32,
 
     zpix_enable: bool,
 };

--- a/libs/zd3d12/build.zig
+++ b/libs/zd3d12/build.zig
@@ -4,6 +4,7 @@ pub const BuildOptions = struct {
     enable_debug_layer: bool = false,
     enable_gbv: bool = false,
     enable_d2d: bool = false,
+    upload_heap_capacity: u32 = 24 * 1024 * 1024,
 };
 
 pub const BuildOptionsStep = struct {
@@ -18,6 +19,7 @@ pub const BuildOptionsStep = struct {
         bos.step.addOption(bool, "enable_debug_layer", bos.options.enable_debug_layer);
         bos.step.addOption(bool, "enable_gbv", bos.options.enable_gbv);
         bos.step.addOption(bool, "enable_d2d", bos.options.enable_d2d);
+        bos.step.addOption(u32, "upload_heap_capacity", bos.options.upload_heap_capacity);
         return bos;
     }
 

--- a/libs/zd3d12/src/zd3d12.zig
+++ b/libs/zd3d12/src/zd3d12.zig
@@ -18,6 +18,7 @@ const hrErrorOnFail = zwin32.hrErrorOnFail;
 const enable_debug_layer = @import("zd3d12_options").enable_debug_layer;
 const enable_gbv = @import("zd3d12_options").enable_gbv;
 const enable_d2d = @import("zd3d12_options").enable_d2d;
+const upload_heap_capacity = @import("zd3d12_options").upload_heap_capacity;
 
 // TODO(mziulek): For now, we always transition *all* subresources.
 const TransitionResourceBarrier = struct {
@@ -47,7 +48,6 @@ pub const GraphicsContext = struct {
     const num_cbv_srv_uav_cpu_descriptors = 16 * 1024;
     const num_cbv_srv_uav_gpu_descriptors = 8 * 1024;
     const max_num_buffered_resource_barriers = 16;
-    const upload_heap_capacity = 24 * 1024 * 1024;
 
     device: *d3d12.IDevice9,
     cmdqueue: *d3d12.ICommandQueue,

--- a/samples/bindless/build.zig
+++ b/samples/bindless/build.zig
@@ -35,6 +35,7 @@ pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
     const zd3d12_options = zd3d12.BuildOptionsStep.init(b, .{
         .enable_debug_layer = options.zd3d12_enable_debug_layer,
         .enable_gbv = options.zd3d12_enable_gbv,
+        .upload_heap_capacity = options.zd3d12_upload_heap_capacity,
     });
     const zmesh_options = zmesh.BuildOptionsStep.init(b, .{});
 


### PR DESCRIPTION
Hello there 👋 

I was recently working on a project where the 24MB upload heap size was not enough.
I thought it would be a good idea to make it configurable. In this PR I'm proposing the addition of a new build option so that users of the library can choose what best fits their renderer.

Another alternative could be to have this and other values configurable at init time instead, but that seemed like a bigger change.

I'm open to feedback of course