### PR TITLE
zgui: minor fixes and AddInputCharactersUTF8

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -243,6 +243,9 @@ pub const io = struct {
     pub const addKeyEvent = zguiIoAddKeyEvent;
     extern fn zguiIoAddKeyEvent(key: Key, down: bool) void;
 
+    pub const addInputCharactersUTF8 = zguiIoAddInputCharactersUTF8;
+    extern fn zguiIoAddInputCharactersUTF8(utf8_chars: ?[*:0]const u8) void;
+
     pub const setKeyEventNativeData = zguiIoSetKeyEventNativeData;
     extern fn zguiIoSetKeyEventNativeData(key: Key, keycode: i32, scancode: i32) void;
 
@@ -298,7 +301,7 @@ pub const Key = enum(u32) {
     four,
     five,
     six,
-    severn,
+    seven,
     eight,
     nine,
     a,
@@ -407,11 +410,11 @@ pub const Key = enum(u32) {
     mouse_wheel_x,
     mouse_wheel_y,
 
-    pub const mod_ctrl: u32 = 1 << 12;
-    pub const mod_shift: u32 = 1 << 13;
-    pub const mod_alt: u32 = 1 << 14;
-    pub const mod_super: u32 = 1 << 15;
-    pub const mod_mask_: u32 = 0xf000;
+    mod_ctrl = 1 << 12,
+    mod_shift = 1 << 13,
+    mod_alt = 1 << 14,
+    mod_super = 1 << 15,
+    mod_mask_ = 0xf000,
 };
 //--------------------------------------------------------------------------------------------------
 pub const WindowFlags = packed struct(u32) {

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1256,6 +1256,10 @@ ZGUI_API void zguiIoAddKeyEvent(ImGuiKey key, bool down) {
     ImGui::GetIO().AddKeyEvent(key, down);
 }
 
+ZGUI_API void zguiIoAddInputCharactersUTF8(const char* utf8_chars) {
+    ImGui::GetIO().AddInputCharactersUTF8(utf8_chars);
+}
+
 ZGUI_API void zguiIoSetKeyEventNativeData(ImGuiKey key, int keycode, int scancode) {
     ImGui::GetIO().SetKeyEventNativeData(key, keycode, scancode);
 }


### PR DESCRIPTION
- Added AddInputCharactersUTF8 
- Fix typo in Key enum 
- Convert key modifiers from u32 to Key. This is because the modifiers can't really be registered with addKeyEvent otherwise since zig's type safety does not allow you to cast these values to enum as they are outside enum range. 