### PR TITLE
Add missing IID_IQueryHeap

### DIFF
--- a/libs/zwin32/src/d3d12.zig
+++ b/libs/zwin32/src/d3d12.zig
@@ -6000,6 +6000,12 @@ pub const IID_IGraphicsCommandList6 = GUID{
     .Data3 = 0x4cfa,
     .Data4 = .{ 0x96, 0xcf, 0x56, 0x89, 0xa9, 0x37, 0x0f, 0x80 },
 };
+pub const IID_IQueryHeap = GUID{
+    .Data1 = 0x0d9658ae,
+    .Data2 = 0xed45,
+    .Data3 = 0x469e,
+    .Data4 = .{ 0xa6, 0x1d, 0x97, 0x0e, 0xc5, 0x83, 0xca, 0xb4 },
+};
 
 // Error return codes from:
 // https://docs.microsoft.com/en-us/windows/win32/direct3d12/d3d12-graphics-reference-returnvalues


### PR DESCRIPTION
Hello there, this PR simply adds the missing GUID for ID3D12QueryHeap.
I've tested this code on a project I'm working on and it works fine, but let me know if I should add a test or something :)

![image](https://user-images.githubusercontent.com/579525/211492104-b6abfcdd-3ca9-4958-8e74-c43f030b013b.png)

