### PR TITLE
samples: add minimal repro of transparency issue

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -47,6 +47,7 @@ pub fn build(b: *std.build.Builder) void {
     installDemo(b, procedural_mesh_wgpu.build(b, options), "procedural_mesh_wgpu");
     installDemo(b, triangle_wgpu.build(b, options), "triangle_wgpu");
     installDemo(b, textured_quad_wgpu.build(b, options), "textured_quad_wgpu");
+    installDemo(b, transparent_quads_wgpu.build(b, options), "transparent_quads_wgpu");
     installDemo(b, gui_test_wgpu.build(b, options), "gui_test_wgpu");
     installDemo(b, audio_experiments_wgpu.build(b, options), "audio_experiments_wgpu");
     installDemo(b, bullet_physics_test_wgpu.build(b, options), "bullet_physics_test_wgpu");
@@ -151,6 +152,7 @@ const zglfw = @import("libs/zglfw/build.zig");
 const triangle_wgpu = @import("samples/triangle_wgpu/build.zig");
 const procedural_mesh_wgpu = @import("samples/procedural_mesh_wgpu/build.zig");
 const textured_quad_wgpu = @import("samples/textured_quad_wgpu/build.zig");
+const transparent_quads_wgpu = @import("samples/transparent_quads_wgpu/build.zig");
 const physically_based_rendering_wgpu = @import("samples/physically_based_rendering_wgpu/build.zig");
 const bullet_physics_test_wgpu = @import("samples/bullet_physics_test_wgpu/build.zig");
 const audio_experiments_wgpu = @import("samples/audio_experiments_wgpu/build.zig");

--- a/samples/transparent_quads_wgpu/build.zig
+++ b/samples/transparent_quads_wgpu/build.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const zgpu = @import("../../libs/zgpu/build.zig");
+const zmath = @import("../../libs/zmath/build.zig");
+const zpool = @import("../../libs/zpool/build.zig");
+const zglfw = @import("../../libs/zglfw/build.zig");
+const zstbi = @import("../../libs/zstbi/build.zig");
+const zgui = @import("../../libs/zgui/build.zig");
+
+const Options = @import("../../build.zig").Options;
+const content_dir = "transparent_quads_wgpu_content/";
+
+pub fn build(b: *std.build.Builder, options: Options) *std.build.LibExeObjStep {
+    const exe = b.addExecutable("transparent_quads_wgpu", thisDir() ++ "/src/transparent_quads_wgpu.zig");
+
+    const exe_options = b.addOptions();
+    exe.addOptions("build_options", exe_options);
+    exe_options.addOption([]const u8, "content_dir", content_dir);
+
+    const install_content_step = b.addInstallDirectory(.{
+        .source_dir = thisDir() ++ "/" ++ content_dir,
+        .install_dir = .{ .custom = "" },
+        .install_subdir = "bin/" ++ content_dir,
+    });
+    exe.step.dependOn(&install_content_step.step);
+
+    exe.setBuildMode(options.build_mode);
+    exe.setTarget(options.target);
+
+    const zgpu_options = zgpu.BuildOptionsStep.init(b, .{});
+    const zgpu_pkg = zgpu.getPkg(&.{ zgpu_options.getPkg(), zpool.pkg, zglfw.pkg });
+
+    const zgui_options = zgui.BuildOptionsStep.init(b, .{ .backend = .glfw_wgpu });
+    const zgui_pkg = zgui.getPkg(&.{zgui_options.getPkg()});
+
+    exe.addPackage(zgpu_pkg);
+    exe.addPackage(zgui_pkg);
+    exe.addPackage(zmath.pkg);
+    exe.addPackage(zglfw.pkg);
+    exe.addPackage(zstbi.pkg);
+
+    zgpu.link(exe, zgpu_options);
+    zgui.link(exe, zgui_options);
+    zglfw.link(exe);
+    zstbi.link(exe);
+
+    return exe;
+}
+
+inline fn thisDir() []const u8 {
+    return comptime std.fs.path.dirname(@src().file) orelse ".";
+}

--- a/samples/transparent_quads_wgpu/src/transparent_quads_wgpu.zig
+++ b/samples/transparent_quads_wgpu/src/transparent_quads_wgpu.zig
@@ -1,0 +1,394 @@
+const std = @import("std");
+const math = std.math;
+const zglfw = @import("zglfw");
+const zgpu = @import("zgpu");
+const wgpu = zgpu.wgpu;
+const zgui = @import("zgui");
+const zm = @import("zmath");
+const zstbi = @import("zstbi");
+
+const content_dir = @import("build_options").content_dir;
+const window_title = "zig-gamedev: transparent quads(wgpu)";
+
+// zig fmt: off
+const wgsl_common =
+\\  struct Uniforms {
+\\      aspect_ratio: f32,
+\\      mip_level: f32,
+\\  }
+\\  @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+;
+const wgsl_vs = wgsl_common ++
+\\  struct VertexOut {
+\\      @builtin(position) position_clip: vec4<f32>,
+\\      @location(0) uv: vec2<f32>,
+\\  }
+\\  @stage(vertex) fn main(
+\\      @location(0) position: vec2<f32>,
+\\      @location(1) uv: vec2<f32>,
+\\  ) -> VertexOut {
+\\      let p = vec2(position.x / uniforms.aspect_ratio, position.y);
+\\      var output: VertexOut;
+\\      output.position_clip = vec4(p, 0.0, 1.0);
+\\      output.uv = uv;
+\\      return output;
+\\  }
+;
+const wgsl_fs = wgsl_common ++
+\\  @group(0) @binding(1) var image: texture_2d<f32>;
+\\  @group(0) @binding(2) var image_sampler: sampler;
+\\  @stage(fragment) fn main(
+\\      @location(0) uv: vec2<f32>,
+\\  ) -> @location(0) vec4<f32> {
+\\      return textureSampleLevel(image, image_sampler, uv, 0);
+\\  }
+// zig fmt: on
+;
+
+const Vertex = extern struct {
+    position: [2]f32,
+    uv: [2]f32,
+};
+
+const Uniforms = extern struct {
+    aspect_ratio: f32,
+    mip_level: f32,
+};
+
+const DemoState = struct {
+    gctx: *zgpu.GraphicsContext,
+
+    pipeline: zgpu.RenderPipelineHandle = .{},
+    bind_group: zgpu.BindGroupHandle,
+
+    vertex_buffer: zgpu.BufferHandle,
+    index_buffer: zgpu.BufferHandle,
+
+    texture: zgpu.TextureHandle,
+    texture_view: zgpu.TextureViewHandle,
+    sampler: zgpu.SamplerHandle,
+
+    mip_level: i32 = 0,
+
+    show_second_quad: bool = false,
+};
+
+fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
+    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const bind_group_layout = gctx.createBindGroupLayout(&.{
+        zgpu.bufferEntry(0, .{ .vertex = true, .fragment = true }, .uniform, true, 0),
+        zgpu.textureEntry(1, .{ .fragment = true }, .float, .tvdim_2d, false),
+        zgpu.samplerEntry(2, .{ .fragment = true }, .filtering),
+    });
+    defer gctx.releaseResource(bind_group_layout);
+
+    // Create a vertex buffer.
+    const vertex_data = [_]Vertex{
+        .{ .position = [2]f32{ -0.9, 0.9 }, .uv = [2]f32{ 0.0, 0.0 } },
+        .{ .position = [2]f32{ 0.9, 0.9 }, .uv = [2]f32{ 1.0, 0.0 } },
+        .{ .position = [2]f32{ 0.9, -0.9 }, .uv = [2]f32{ 1.0, 1.0 } },
+        .{ .position = [2]f32{ -0.9, -0.9 }, .uv = [2]f32{ 0.0, 1.0 } },
+        .{ .position = [2]f32{ 0.5, 0.9 }, .uv = [2]f32{ 0.0, 0.0 } },
+        .{ .position = [2]f32{ 0.9, 0.9 }, .uv = [2]f32{ 1.0, 0.0 } },
+        .{ .position = [2]f32{ 0.9, 0.5 }, .uv = [2]f32{ 1.0, 1.0 } },
+        .{ .position = [2]f32{ 0.5, 0.5 }, .uv = [2]f32{ 0.0, 1.0 } },
+    };
+    const vertex_buffer = gctx.createBuffer(.{
+        .usage = .{ .copy_dst = true, .vertex = true },
+        .size = vertex_data.len * @sizeOf(Vertex),
+    });
+    gctx.queue.writeBuffer(gctx.lookupResource(vertex_buffer).?, 0, Vertex, vertex_data[0..]);
+
+    // Create an index buffer.
+    const index_data = [_]u16{ 0, 1, 3, 1, 2, 3, 4, 5, 7, 5, 6, 7 };
+    const index_buffer = gctx.createBuffer(.{
+        .usage = .{ .copy_dst = true, .index = true },
+        .size = index_data.len * @sizeOf(u16),
+    });
+    gctx.queue.writeBuffer(gctx.lookupResource(index_buffer).?, 0, u16, index_data[0..]);
+
+    zstbi.init(arena);
+    defer zstbi.deinit();
+
+    var image = try zstbi.Image.init(content_dir ++ "light.png", 4);
+    defer image.deinit();
+
+    // Create a texture.
+    const texture = gctx.createTexture(.{
+        .usage = .{ .texture_binding = true, .copy_dst = true },
+        .size = .{
+            .width = image.width,
+            .height = image.height,
+            .depth_or_array_layers = 1,
+        },
+        .format = zgpu.imageInfoToTextureFormat(
+            image.num_components,
+            image.bytes_per_component,
+            image.is_hdr,
+        ),
+    });
+    const texture_view = gctx.createTextureView(texture, .{});
+
+    gctx.queue.writeTexture(
+        .{ .texture = gctx.lookupResource(texture).? },
+        .{
+            .bytes_per_row = image.bytes_per_row,
+            .rows_per_image = image.height,
+        },
+        .{ .width = image.width, .height = image.height },
+        u8,
+        image.data,
+    );
+
+    // Create a sampler.
+    const sampler = gctx.createSampler(.{});
+
+    const bind_group = gctx.createBindGroup(bind_group_layout, &.{
+        .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = 256 },
+        .{ .binding = 1, .texture_view_handle = texture_view },
+        .{ .binding = 2, .sampler_handle = sampler },
+    });
+
+    const demo = try allocator.create(DemoState);
+    demo.* = .{
+        .gctx = gctx,
+        .bind_group = bind_group,
+        .vertex_buffer = vertex_buffer,
+        .index_buffer = index_buffer,
+        .texture = texture,
+        .texture_view = texture_view,
+        .sampler = sampler,
+    };
+
+    // (Async) Create a render pipeline.
+    {
+        const pipeline_layout = gctx.createPipelineLayout(&.{
+            bind_group_layout,
+        });
+        defer gctx.releaseResource(pipeline_layout);
+
+        const vs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_vs, "vs");
+        defer vs_module.release();
+
+        const fs_module = zgpu.createWgslShaderModule(gctx.device, wgsl_fs, "fs");
+        defer fs_module.release();
+
+        const blend_state = wgpu.BlendState{
+            .color = wgpu.BlendComponent{
+                .operation = .add,
+                .src_factor = .src_alpha,
+                .dst_factor = .one_minus_src_alpha,
+            },
+            .alpha = wgpu.BlendComponent{
+                .operation = .add,
+                .src_factor = .src_alpha,
+                .dst_factor = .one_minus_src_alpha,
+            },
+        };
+
+        const color_targets = [_]wgpu.ColorTargetState{.{
+            .format = zgpu.GraphicsContext.swapchain_format,
+            .blend = &blend_state,
+        }};
+
+        const vertex_attributes = [_]wgpu.VertexAttribute{
+            .{ .format = .float32x2, .offset = 0, .shader_location = 0 },
+            .{ .format = .float32x2, .offset = @offsetOf(Vertex, "uv"), .shader_location = 1 },
+        };
+        const vertex_buffers = [_]wgpu.VertexBufferLayout{.{
+            .array_stride = @sizeOf(Vertex),
+            .attribute_count = vertex_attributes.len,
+            .attributes = &vertex_attributes,
+        }};
+
+        // Create a render pipeline.
+        const pipeline_descriptor = wgpu.RenderPipelineDescriptor{
+            .vertex = .{
+                .module = vs_module,
+                .entry_point = "main",
+                .buffer_count = vertex_buffers.len,
+                .buffers = &vertex_buffers,
+            },
+            .primitive = .{
+                .front_face = .cw,
+                .cull_mode = .back,
+                .topology = .triangle_list,
+            },
+            .fragment = &.{
+                .module = fs_module,
+                .entry_point = "main",
+                .target_count = color_targets.len,
+                .targets = &color_targets,
+            },
+        };
+        gctx.createRenderPipelineAsync(allocator, pipeline_layout, pipeline_descriptor, &demo.pipeline);
+    }
+
+    return demo;
+}
+
+fn destroy(allocator: std.mem.Allocator, demo: *DemoState) void {
+    demo.gctx.destroy(allocator);
+    allocator.destroy(demo);
+}
+
+fn update(demo: *DemoState) void {
+    zgui.backend.newFrame(
+        demo.gctx.swapchain_descriptor.width,
+        demo.gctx.swapchain_descriptor.height,
+    );
+
+    zgui.setNextWindowPos(.{ .x = 20.0, .y = 20.0, .cond = .always });
+    zgui.setNextWindowSize(.{ .w = -1.0, .h = -1.0, .cond = .always });
+
+    if (zgui.begin("Demo Settings", .{ .flags = .{ .no_move = true, .no_resize = true } })) {
+        zgui.bulletText(
+            "Average : {d:.3} ms/frame ({d:.1} fps)",
+            .{ demo.gctx.stats.average_cpu_time, demo.gctx.stats.fps },
+        );
+        zgui.spacing();
+        _ = zgui.checkbox("Show second quad", .{
+            .v = &demo.show_second_quad,
+        });
+    }
+    zgui.end();
+}
+
+fn draw(demo: *DemoState) void {
+    const gctx = demo.gctx;
+    const fb_width = gctx.swapchain_descriptor.width;
+    const fb_height = gctx.swapchain_descriptor.height;
+
+    const back_buffer_view = gctx.swapchain.getCurrentTextureView();
+    defer back_buffer_view.release();
+
+    const commands = commands: {
+        const encoder = gctx.device.createCommandEncoder(null);
+        defer encoder.release();
+
+        // Main pass.
+        pass: {
+            const vb_info = gctx.lookupResourceInfo(demo.vertex_buffer) orelse break :pass;
+            const ib_info = gctx.lookupResourceInfo(demo.index_buffer) orelse break :pass;
+            const pipeline = gctx.lookupResource(demo.pipeline) orelse break :pass;
+            const bind_group = gctx.lookupResource(demo.bind_group) orelse break :pass;
+
+            const color_attachments = [_]wgpu.RenderPassColorAttachment{.{
+                .view = back_buffer_view,
+                .load_op = .clear,
+                .store_op = .store,
+            }};
+            const render_pass_info = wgpu.RenderPassDescriptor{
+                .color_attachment_count = color_attachments.len,
+                .color_attachments = &color_attachments,
+            };
+            const pass = encoder.beginRenderPass(render_pass_info);
+            defer {
+                pass.end();
+                pass.release();
+            }
+
+            pass.setVertexBuffer(0, vb_info.gpuobj.?, 0, vb_info.size);
+            pass.setIndexBuffer(ib_info.gpuobj.?, .uint16, 0, ib_info.size);
+
+            pass.setPipeline(pipeline);
+
+            const mem = gctx.uniformsAllocate(Uniforms, 1);
+            mem.slice[0] = .{
+                .aspect_ratio = @intToFloat(f32, fb_width) / @intToFloat(f32, fb_height),
+                .mip_level = @intToFloat(f32, demo.mip_level),
+            };
+            pass.setBindGroup(0, bind_group, &.{mem.offset});
+            pass.drawIndexed(if (demo.show_second_quad) 12 else 6, if (demo.show_second_quad) 2 else 1, 0, 0, 0);
+        }
+
+        // Gui pass.
+        {
+            const color_attachments = [_]wgpu.RenderPassColorAttachment{.{
+                .view = back_buffer_view,
+                .load_op = .load,
+                .store_op = .store,
+            }};
+            const render_pass_info = wgpu.RenderPassDescriptor{
+                .color_attachment_count = color_attachments.len,
+                .color_attachments = &color_attachments,
+            };
+            const pass = encoder.beginRenderPass(render_pass_info);
+            defer {
+                pass.end();
+                pass.release();
+            }
+
+            zgui.backend.draw(pass);
+        }
+
+        break :commands encoder.finish(null);
+    };
+    defer commands.release();
+
+    gctx.submit(&.{commands});
+    _ = gctx.present();
+}
+
+pub fn main() !void {
+    zglfw.init() catch {
+        std.log.err("Failed to initialize GLFW library.", .{});
+        return;
+    };
+    defer zglfw.terminate();
+
+    // Change current working directory to where the executable is located.
+    {
+        var buffer: [1024]u8 = undefined;
+        const path = std.fs.selfExeDirPath(buffer[0..]) catch ".";
+        std.os.chdir(path) catch {};
+    }
+
+    const window = zglfw.Window.create(1600, 1000, window_title, null) catch {
+        std.log.err("Failed to create demo window.", .{});
+        return;
+    };
+    defer window.destroy();
+    window.setSizeLimits(400, 400, -1, -1);
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const allocator = gpa.allocator();
+
+    const demo = create(allocator, window) catch {
+        std.log.err("Failed to initialize the demo.", .{});
+        return;
+    };
+    defer destroy(allocator, demo);
+
+    const scale_factor = scale_factor: {
+        const scale = window.getContentScale();
+        break :scale_factor math.max(scale[0], scale[1]);
+    };
+
+    zgui.init(allocator);
+    defer zgui.deinit();
+
+    _ = zgui.io.addFontFromFile(content_dir ++ "Roboto-Medium.ttf", math.floor(16.0 * scale_factor));
+
+    zgui.backend.init(
+        window,
+        demo.gctx.device,
+        @enumToInt(zgpu.GraphicsContext.swapchain_format),
+    );
+    defer zgui.backend.deinit();
+
+    zgui.getStyle().scaleAllSizes(scale_factor);
+
+    while (!window.shouldClose() and window.getKey(.escape) != .press) {
+        zglfw.pollEvents();
+        update(demo);
+        draw(demo);
+    }
+}

--- a/samples/transparent_quads_wgpu/transparent_quads_wgpu_content/Roboto-Medium.ttf
+++ b/samples/transparent_quads_wgpu/transparent_quads_wgpu_content/Roboto-Medium.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559132c89ad51d8a2ba5b171887a44a7ba93776e205f553573de228e64b45f8
+size 162588

--- a/samples/transparent_quads_wgpu/transparent_quads_wgpu_content/light.png
+++ b/samples/transparent_quads_wgpu/transparent_quads_wgpu_content/light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8870aca3437de5f16f013f97f3f6ceb6e1053791f72f30a310dbe661dd2418e4
+size 21091


### PR DESCRIPTION
Hi!

You don't need to merge this PR, I just wasn't sure of the easiest way to showcase this. I'm still struggling with the issue of multiple transparent sprites becoming more opaque even when they aren't overlapping.

You should just be able to run using `zig build transparent_quads_wgpu-run`.

I just simply copied the `textured_quad_wgpu` sample and added a second quad, and set the blend states. There is a checkbox in the gui to show the second quad, and you can observe the first quad becoming more opaque when the second quad draws, almost as if the first quad is being redrawn over itself.

I've been wracking my brain over this for quite a while, and I've tried every combination of blend state that I can think of, and I'm beginning to think it doesn't have anything to do with the blend state but something going on with wgpu. I thought maybe trying to reproduce this as minimally as possible would reveal something but the behavior seems to be the same. 

Anyway, if you have time to take a look at this it would be much appreciated, Thanks!

