### PR TITLE
Add support for loading 64bpp RGBA textures

### DIFF
--- a/libs/zd3d12/src/zd3d12.zig
+++ b/libs/zd3d12/src/zd3d12.zig
@@ -1463,6 +1463,7 @@ pub const GraphicsContext = struct {
             if (eql(u8, asBytes(&pixel_format), asBytes(&wic.GUID_PixelFormat32bppBGR))) break :blk 4;
             if (eql(u8, asBytes(&pixel_format), asBytes(&wic.GUID_PixelFormat32bppBGRA))) break :blk 4;
             if (eql(u8, asBytes(&pixel_format), asBytes(&wic.GUID_PixelFormat32bppPBGRA))) break :blk 4;
+            if (eql(u8, asBytes(&pixel_format), asBytes(&wic.GUID_PixelFormat64bppRGBA))) break :blk 4;
 
             if (eql(u8, asBytes(&pixel_format), asBytes(&wic.GUID_PixelFormat8bppGray))) break :blk 1;
             if (eql(u8, asBytes(&pixel_format), asBytes(&wic.GUID_PixelFormat8bppAlpha))) break :blk 1;

--- a/libs/zwin32/src/wincodec.zig
+++ b/libs/zwin32/src/wincodec.zig
@@ -366,6 +366,13 @@ pub const GUID_PixelFormat32bppPBGRA = PixelFormatGUID{
     .Data4 = .{ 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x10 },
 };
 
+pub const GUID_PixelFormat64bppRGBA = PixelFormatGUID{
+    .Data1 = 0x6fddc324,
+    .Data2 = 0x4e03,
+    .Data3 = 0x4bfe,
+    .Data4 = .{ 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x16 },
+};
+
 pub const GUID_PixelFormat8bppGray = PixelFormatGUID{
     .Data1 = 0x6fddc324,
     .Data2 = 0x4e03,


### PR DESCRIPTION
Hello again, I've encountered some 64bbp RGBA textures on [Poly Haven](https://polyhaven.com/) and had to add support for them to wincoded.zig and zd3d12.zig.

I also have a question a bit related to this. Have you planned or thought about adding support for loading DDS textures? I used them in my C++ experiments via [DirectXTK12](https://github.com/Microsoft/DirectXTK12) and they're really nice to work with. It might also be something I can help with if you want.

Cheers