### PR TITLE
zwin32.zig use std.log.debug instead of std.debug.print

### DIFF
--- a/libs/zwin32/src/zwin32.zig
+++ b/libs/zwin32/src/zwin32.zig
@@ -136,7 +136,7 @@ pub fn hrToError(hr: HRESULT) HResultError {
         w32.S_FALSE => w32.MiscError.S_FALSE,
         // treat unknown error return codes as E_FAIL
         else => blk: {
-            std.debug.print("HRESULT error 0x{x} not recognized treating as E_FAIL.", .{@bitCast(c_ulong, hr)});
+            std.log.debug("HRESULT error 0x{x} not recognized treating as E_FAIL.", .{@bitCast(c_ulong, hr)});
             break :blk w32.Error.FAIL;
         },
     };


### PR DESCRIPTION
This small change allows me to avoid the following error when cross-compiling with zwin32 package present
```
/home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/os.zig:151:24: error: root struct of file 'c' has no member named 'fd_t'
pub const fd_t = system.fd_t;
                 ~~~~~~^~~~~
referenced by:
    Handle: /home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/fs/file.zig:31:26
    File: /home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/fs/file.zig:15:13
    File: /home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/fs/file.zig:13:18
    File: /home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/fs.zig:15:40
    File: /home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/io.zig:12:20
    getStdErr: /home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/io.zig:74:20
    print__anon_11782: /home/chris/zig/0.11.0-dev.1390+74b72a766/files/lib/std/debug.zig:92:22
    hrToError: libs/zwin32/src/zwin32.zig:138:22
    hrErrorOnFail: libs/zwin32/src/zwin32.zig:50:16
```