### PR TITLE
zbullet: Add Body.setCollisionFlags

### DIFF
--- a/libs/zbullet/libs/cbullet/cbullet.cpp
+++ b/libs/zbullet/libs/cbullet/cbullet.cpp
@@ -1520,6 +1520,12 @@ void cbtBodySetCcdMotionThreshold(CbtBodyHandle body_handle, float threshold) {
     body->setCcdMotionThreshold(threshold);
 }
 
+void cbtBodySetCollisionFlags(CbtBodyHandle body_handle, int flags) {
+    assert(body_handle && cbtBodyIsCreated(body_handle));
+    auto body = (btRigidBody*)body_handle;
+    body->setCollisionFlags(flags);
+}
+
 CbtBodyHandle cbtConGetFixedBody(void) {
     return (CbtBodyHandle)&btTypedConstraint::getFixedBody();
 }

--- a/libs/zbullet/libs/cbullet/cbullet.h
+++ b/libs/zbullet/libs/cbullet/cbullet.h
@@ -390,6 +390,8 @@ void cbtBodySetCcdSweptSphereRadius(CbtBodyHandle body_handle, float radius);
 float cbtBodyGetCcdMotionThreshold(CbtBodyHandle body_handle);
 void cbtBodySetCcdMotionThreshold(CbtBodyHandle body_handle, float threshold);
 
+void cbtBodySetCollisionFlags(CbtBodyHandle body_handle, int flags);
+
 //
 // Constraints
 //

--- a/libs/zbullet/src/zbullet.zig
+++ b/libs/zbullet/src/zbullet.zig
@@ -643,6 +643,21 @@ pub const BodyActivationState = enum(c_int) {
     simulation_disabled = 5,
 };
 
+pub const CollisionFlags = packed struct(c_int) {
+    static_object: bool = false,
+    kinematic_object: bool = false,
+    no_contact_response: bool = false,
+    custom_material_callback: bool = false,
+    character_object: bool = false,
+    disable_visualize_object: bool = false,
+    disable_spu_collision_processing: bool = false,
+    has_contact_stiffness_damping: bool = false,
+    has_custom_debug_rendering_color: bool = false,
+    has_friction_anchor: bool = false,
+    has_collision_sound_trigger: bool = false,
+    _padding: u21 = 0,
+};
+
 pub fn initBody(
     mass: f32,
     transform: *const [12]f32,
@@ -744,6 +759,11 @@ const BodyImpl = opaque {
 
     pub const setCcdMotionThreshold = cbtBodySetCcdMotionThreshold;
     extern fn cbtBodySetCcdMotionThreshold(body: Body, threshold: f32) void;
+
+    pub fn setCollisionFlags(body: Body, flags: CollisionFlags) void {
+        cbtBodySetCollisionFlags(body, @bitCast(c_int, flags));
+    }
+    extern fn cbtBodySetCollisionFlags(body: Body, flags: c_int) void;
 
     pub const setMassProps = cbtBodySetMassProps;
     extern fn cbtBodySetMassProps(body: Body, mass: f32, inertia: *const [3]f32) void;


### PR DESCRIPTION
Needed these to disable collision for "sensor-like" objects. Lots of other neat things you can do with them apparently, like disabling debug drawing for a body.