### PR TITLE
zgui: Expose `beginPopupContextItem`

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3082,6 +3082,8 @@ extern fn zguiEndTooltip() void;
 
 /// `pub fn beginPopupContextWindow() bool`
 pub const beginPopupContextWindow = zguiBeginPopupContextWindow;
+/// `pub fn beginPopupContextItem() bool`
+pub const beginPopupContextItem = zguiBeginPopupContextItem;
 pub const PopupFlags = packed struct(u32) {
     mouse_button_left: bool = false,
     mouse_button_right: bool = false,
@@ -3106,6 +3108,7 @@ pub const endPopup = zguiEndPopup;
 /// `pub fn closeCurrentPopup() void`
 pub const closeCurrentPopup = zguiCloseCurrentPopup;
 extern fn zguiBeginPopupContextWindow() bool;
+extern fn zguiBeginPopupContextItem() bool;
 extern fn zguiBeginPopupModal(name: [*:0]const u8, popen: ?*bool, flags: WindowFlags) bool;
 extern fn zguiEndPopup() void;
 extern fn zguiOpenPopup(str_id: [*:0]const u8, flags: PopupFlags) void;

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1439,6 +1439,10 @@ ZGUI_API bool zguiBeginPopupContextWindow(void) {
     return ImGui::BeginPopupContextWindow();
 }
 
+ZGUI_API bool zguiBeginPopupContextItem(void) {
+    return ImGui::BeginPopupContextItem();
+}
+
 ZGUI_API bool zguiBeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags flags) {
     return ImGui::BeginPopupModal(name, p_open, flags);
 }


### PR DESCRIPTION
This is useful for adding context menus to tree nodes items and similar.