### PR TITLE
zmesh simplify

### DIFF
--- a/libs/zmesh/build.zig
+++ b/libs/zmesh/build.zig
@@ -58,6 +58,7 @@ pub const Package = struct {
         zmesh_c_cpp.addCSourceFile(thisDir() ++ "/libs/meshoptimizer/vfetchanalyzer.cpp", &.{""});
         zmesh_c_cpp.addCSourceFile(thisDir() ++ "/libs/meshoptimizer/overdrawoptimizer.cpp", &.{""});
         zmesh_c_cpp.addCSourceFile(thisDir() ++ "/libs/meshoptimizer/overdrawanalyzer.cpp", &.{""});
+        zmesh_c_cpp.addCSourceFile(thisDir() ++ "/libs/meshoptimizer/simplifier.cpp", &.{""});
         zmesh_c_cpp.addCSourceFile(thisDir() ++ "/libs/meshoptimizer/allocator.cpp", &.{""});
 
         zmesh_c_cpp.addIncludePath(thisDir() ++ "/libs/cgltf");

--- a/libs/zmesh/libs/meshoptimizer/indexgenerator.cpp
+++ b/libs/zmesh/libs/meshoptimizer/indexgenerator.cpp
@@ -187,7 +187,7 @@ size_t meshopt_generateVertexRemap(unsigned int* destination, const unsigned int
 	using namespace meshopt;
 
 	assert(indices || index_count == vertex_count);
-	assert(index_count % 3 == 0);
+	assert(!indices || index_count % 3 == 0);
 	assert(vertex_size > 0 && vertex_size <= 256);
 
 	meshopt_Allocator allocator;

--- a/libs/zmesh/src/zmeshoptimizer.zig
+++ b/libs/zmesh/src/zmeshoptimizer.zig
@@ -152,6 +152,57 @@ pub inline fn analyzeVertexFetch(
     return meshopt_analyzeVertexFetch(indices.ptr, indices.len, vertex_count, vertex_size);
 }
 
+// Simplifier
+pub inline fn simplify(
+    comptime T: type,
+    destination: []u32,
+    indices: []const u32,
+    index_count: usize,
+    vertices: []const T,
+    vertex_count: usize,
+    target_index_count: usize,
+    target_error: f32,
+    options: u32,
+    out_result_error: *f32,
+) usize {
+    return meshopt_simplify(
+        destination.ptr,
+        indices.ptr,
+        index_count,
+        vertices.ptr,
+        vertex_count,
+        @sizeOf(T),
+        target_index_count,
+        target_error,
+        options,
+        out_result_error,
+    );
+}
+
+pub inline fn simplifySloppy(
+    comptime T: type,
+    destination: []u32,
+    indices: []const u32,
+    index_count: usize,
+    vertices: []const T,
+    vertex_count: usize,
+    target_index_count: usize,
+    target_error: f32,
+    out_result_error: *f32,
+) usize {
+    return meshopt_simplifySloppy(
+        destination.ptr,
+        indices.ptr,
+        index_count,
+        vertices.ptr,
+        vertex_count,
+        @sizeOf(T),
+        target_index_count,
+        target_error,
+        out_result_error,
+    );
+}
+
 // Mesh shading
 pub inline fn buildMeshletsBound(index_count: usize, max_vertices: usize, max_triangles: usize) usize {
     return meshopt_buildMeshletsBound(index_count, max_vertices, max_triangles);
@@ -255,6 +306,29 @@ extern fn meshopt_analyzeVertexFetch(
     vertex_count: usize,
     vertex_size: usize,
 ) VertexFetchStatistics;
+extern fn meshopt_simplify(
+    destination: [*]u32,
+    indices: [*]const u32,
+    index_count: usize,
+    vertices: *const anyopaque,
+    vertex_count: usize,
+    vertex_stride: usize,
+    target_index_count: usize,
+    target_error: f32,
+    options: u32,
+    out_result_error: *f32,
+) usize;
+extern fn meshopt_simplifySloppy(
+    destination: [*]u32,
+    indices: [*]const u32,
+    index_count: usize,
+    vertices: *const anyopaque,
+    vertex_count: usize,
+    vertex_stride: usize,
+    target_index_count: usize,
+    target_error: f32,
+    out_result_error: *f32,
+) usize;
 extern fn meshopt_buildMeshletsBound(
     index_count: usize,
     max_vertices: usize,


### PR DESCRIPTION
Hello there, this PR upgrades `meshoptimizer` to version 0.18 and exposes `meshopt_simplify` and `meshopt_simplifySloppy`.

I've tested both `simplify` and `simplifySloppy`, but the SciFi Helmet couldn't be simplified via `simplify`. I was able to produce some LODs via `simplifySloppy` instead.

I'm not sure if the `bindless` sample is the best place for also showing how to LOD, but for now I've put them there.