### PR TITLE
zpool: Make handles extern for better C interop

### DIFF
--- a/libs/zpool/src/handle.zig
+++ b/libs/zpool/src/handle.zig
@@ -67,7 +67,7 @@ pub fn Handle(
     const UInt = utils.UInt;
     const AddressableUInt = utils.AddressableUInt;
 
-    return struct {
+    return extern struct {
         const Self = @This();
 
         const HandleType = Self;


### PR DESCRIPTION
I found myself wanting to return handles from exported functions for FFI use. I think it makes sense to make handles `extern` to make this easier, since handles are just a wrapped integer anyways.

(There shouldn't be any performance penalty doing this, right?)