### PR TITLE
Support building dependencies as a shared library

### DIFF
--- a/libs/zgui/README.md
+++ b/libs/zgui/README.md
@@ -93,6 +93,26 @@ while (...) {
 }
 ```
 
+### Building a shared library
+
+If your project spans multiple zig modules that both use ImGui, such as an exe paired with a dll, you may want to build the `zgui` dependencies (`zgui_pkg.zgui_c_cpp`) as a shared library. This can be enabled with the `shared` build option. Then, in `build.zig`, use `zgui_pkg.link` to link `zgui` to all the modules that use ImGui.
+
+When built this way, the ImGui context will be located in the shared library. However, the `zgui` zig code (which is compiled separately into each module) requires its own memory buffer which has to be initialized separately with `initNoContext`.
+
+In your executable:
+```
+const zgui = @import("zgui");
+zgui.init(allocator);
+defer zgui.deinit();
+```
+
+In your shared library:
+```
+const zgui = @import("zgui");
+zgui.initNoContext(allocator);
+defer zgui.deinitNoContxt();
+```
+
 ### DrawList API
 
 ```zig

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -50,6 +50,17 @@ pub fn deinit() void {
         mem_allocator = null;
     }
 }
+pub fn initNoContext(allocator: std.mem.Allocator) void {
+    if (temp_buffer == null) {
+        temp_buffer = std.ArrayList(u8).init(allocator);
+        temp_buffer.?.resize(3 * 1024 + 1) catch unreachable;
+    }
+}
+pub fn deinitNoContext() void {
+    if (temp_buffer) |buf| {
+        buf.deinit();
+    }
+}
 extern fn zguiCreateContext(shared_font_atlas: ?*const anyopaque) Context;
 extern fn zguiDestroyContext(ctx: ?Context) void;
 extern fn zguiGetCurrentContext() ?Context;
@@ -92,16 +103,17 @@ extern fn zguiSetAllocatorFunctions(
     free_func: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.C) void,
 ) void;
 //--------------------------------------------------------------------------------------------------
-pub const ConfigFlags = enum(u32) {
-    none = 0,
-    nav_enable_keyboard = 1 << 0,
-    nav_enable_gamepad = 1 << 1,
-    nav_enable_set_mouse_pos = 1 << 2,
-    nav_no_capture_keyboard = 1 << 3,
-    no_mouse = 1 << 4,
-    no_mouse_cursor_change = 1 << 5,
-    is_srgb = 1 << 20,
-    is_touch_screen = 1 << 21,
+pub const ConfigFlags = packed struct(u32) {
+    nav_enable_keyboard: bool = false,
+    nav_enable_gamepad: bool = false,
+    nav_enable_set_mouse_pos: bool = false,
+    nav_no_capture_keyboard: bool = false,
+    no_mouse: bool = false,
+    no_mouse_cursor_change: bool = false,
+    user_storage: u14 = 0,
+    is_srgb: bool = false,
+    is_touch_screen: bool = false,
+    _padding: u10 = 0,
 };
 
 pub const FontConfig = extern struct {
@@ -3061,6 +3073,15 @@ pub fn menuItem(label: [:0]const u8, args: MenuItem) bool {
     return zguiMenuItem(label, if (args.shortcut) |s| s.ptr else null, args.selected, args.enabled);
 }
 
+const MenuItemPtr = struct {
+    shortcut: ?[:0]const u8 = null,
+    selected: *bool,
+    enabled: bool = true,
+};
+pub fn menuItemPtr(label: [:0]const u8, args: MenuItemPtr) bool {
+    return zguiMenuItemPtr(label, if (args.shortcut) |s| s.ptr else null, args.selected, args.enabled);
+}
+
 extern fn zguiBeginMenuBar() bool;
 extern fn zguiEndMenuBar() void;
 extern fn zguiBeginMainMenuBar() bool;
@@ -3068,6 +3089,7 @@ extern fn zguiEndMainMenuBar() void;
 extern fn zguiBeginMenu(label: [*:0]const u8, enabled: bool) bool;
 extern fn zguiEndMenu() void;
 extern fn zguiMenuItem(label: [*:0]const u8, shortcut: ?[*:0]const u8, selected: bool, enabled: bool) bool;
+extern fn zguiMenuItemPtr(label: [*:0]const u8, shortcut: ?[*:0]const u8, selected: *bool, enabled: bool) bool;
 //--------------------------------------------------------------------------------------------------
 //
 // Popups

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1,7 +1,11 @@
 #include "./imgui/imgui.h"
 #include "./imgui/implot.h"
 
-#define ZGUI_API extern "C"
+#ifndef ZGUI_API
+#define ZGUI_API
+#endif
+
+extern "C" {
 
 /*
 #include <stdio.h>
@@ -1427,6 +1431,10 @@ ZGUI_API bool zguiMenuItem(const char* label, const char* shortcut, bool selecte
     return ImGui::MenuItem(label, shortcut, selected, enabled);
 }
 
+ZGUI_API bool zguiMenuItemPtr(const char* label, const char* shortcut, bool* selected, bool enabled) {
+    return ImGui::MenuItem(label, shortcut, selected, enabled);
+}
+
 ZGUI_API void zguiBeginTooltip(void) {
     ImGui::BeginTooltip();
 }
@@ -2300,3 +2308,4 @@ ZGUI_API void zguiPlot_EndPlot(void) {
     ImPlot::EndPlot();
 }
 //--------------------------------------------------------------------------------------------------
+} /* extern "C" */


### PR DESCRIPTION
- Add build option to generated a shared library
- Add gui.initNoContext / gui.deinitNoContext
- Update ConfigFlags to be a packed struct
- Add gui.menuItemPtr / zguiMenuItemPtr
- Add extern "C" and ZGUI_API define to zgui.cpp