### PR TITLE
Expose glfwSetTime in zglfw

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -691,7 +691,8 @@ test "zglfw.basic" {
         _ = try getRequiredInstanceExtensions();
     }
 
-    _ = getTime();
+    setTime(100);
+    try std.testing.expectApproxEqAbs(@as(f64, 100), getTime(), 0.5);
 
     const primary_monitor = Monitor.getPrimary();
     if (primary_monitor) |monitor| {

--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -50,6 +50,10 @@ extern fn glfwGetRequiredInstanceExtensions(count: *u32) ?*?[*:0]const u8;
 pub const getTime = glfwGetTime;
 extern fn glfwGetTime() f64;
 
+/// `pub fn setTime(time: f64) void`
+pub const setTime = glfwSetTime;
+extern fn glfwSetTime(time: f64) void;
+
 pub const Error = error{
     NotInitialized,
     NoCurrentContext,


### PR DESCRIPTION
Just a tiny change to add a `glfwSetTime` wrapper to zglfw.

It's a good practice when using `glfwGetTime` to occasionally also use `glfwSetTime` to reset the counter (and do whatever else you need to ensure the discontinuity doesn't manifest itself in your simulation logic).  Otherwise you eventually start losing floating point precision and that can cause a lot of subtle issues.