### PR TITLE
zpool: Fix broken Pool.init()

### DIFF
--- a/libs/zpool/src/pool.zig
+++ b/libs/zpool/src/pool.zig
@@ -126,7 +126,7 @@ pub fn Pool(
         /// memory allocation backed by `std.MultiArrayList`.
         pub fn init(allocator: Allocator) Self {
             var self = Self{ ._allocator = allocator };
-            updateSlices(self);
+            updateSlices(&self);
             return self;
         }
 
@@ -708,6 +708,12 @@ const DeinitCounter = struct {
 };
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+test "Pool.init()" {
+    const TestPool = Pool(8, 8, void, struct {});
+    var pool = TestPool.init(std.testing.allocator);
+    defer pool.deinit();
+}
 
 test "Pool with no columns" {
     const TestPool = Pool(8, 8, void, struct {});


### PR DESCRIPTION
Noticed this constructor is not used anywhere, so it was silently broken. Would probably make sense to test adding/removing handles from a 0 capacity pool as well, but for now I just added a simple test so the init() function is compiled and analyzed by Zig.