### PR TITLE
zopengl: glFramebufferTexture does not exist in ES profile

### DIFF
--- a/libs/zopengl/src/zopengl.zig
+++ b/libs/zopengl/src/zopengl.zig
@@ -985,10 +985,6 @@ pub fn loadEsProfile(loader: LoaderFn, major: u32, minor: u32) !void {
             "glGetFramebufferAttachmentParameteriv",
         );
         bindings.generateMipmap = try getProcAddress(@TypeOf(bindings.generateMipmap), "glGenerateMipmap");
-        bindings.framebufferTexture = try getProcAddress(
-            @TypeOf(bindings.framebufferTexture),
-            "glFramebufferTexture",
-        );
     }
 
     // OpenGL ES 3.0


### PR DESCRIPTION
I'm not sure how I let this one creep in but it doesn't exist in ES profile, sorry!

Seems like some desktop drivers will load something even if in ES mode. I will verify with different driver from now on