### PR TITLE
build.zig: expose min_zig_version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 
-const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 11, .patch = 0, .pre = "dev.2560" };
+pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 11, .patch = 0, .pre = "dev.2560" };
 
 pub fn build(b: *std.Build) void {
     //


### PR DESCRIPTION
Expose for usage in project tracking same Zig version as zig-gamedev dependency