### PR TITLE
zopengl: debug api bindings & ES aliasing

### DIFF
--- a/libs/zopengl/src/bindings.zig
+++ b/libs/zopengl/src/bindings.zig
@@ -2239,7 +2239,7 @@ pub const FRAMEBUFFER_INCOMPLETE_DIMENSIONS = 0x8CD9;
 // OES_vertex_array_object (OpenGL ES Extension #71)
 //
 //--------------------------------------------------------------------------------------------------
-pub const VERTEX_ARRAY_BINDING_OES = 0x85B5;
+pub const VERTEX_ARRAY_BINDING_OES = VERTEX_ARRAY_BINDING;
 
 pub var bindVertexArrayOES: *const fn (array: Uint) callconv(.C) void = undefined;
 pub var deleteVertexArraysOES: *const fn (

--- a/libs/zopengl/src/bindings.zig
+++ b/libs/zopengl/src/bindings.zig
@@ -1987,6 +1987,88 @@ pub var bindImageTexture: *const fn (
     format: Enum,
 ) callconv(.C) void = undefined;
 pub var memoryBarrier: *const fn (barriers: Bitfield) callconv(.C) void = undefined;
+
+//--------------------------------------------------------------------------------------------------
+//
+// OpenGL 4.3 (Core Profile)
+//
+//--------------------------------------------------------------------------------------------------
+pub const DEBUGPROC = *const fn (
+    source: Enum,
+    type: Enum,
+    id: Uint,
+    severity: Enum,
+    length: Sizei,
+    message: [*c]const Char,
+    userParam: *const anyopaque,
+) void;
+
+pub var debugMessageControl: *const fn (
+    source: Enum,
+    type: Enum,
+    severity: Enum,
+    count: Sizei,
+    ids: [*c]const Uint,
+    enabled: Boolean,
+) callconv(.C) void = undefined;
+pub var debugMessageInsert: *const fn (
+    source: Enum,
+    type: Enum,
+    id: Uint,
+    severity: Enum,
+    length: Sizei,
+    buf: [*c]const u8,
+) callconv(.C) void = undefined;
+pub var debugMessageCallback: *const fn (
+    callback: DEBUGPROC,
+    userParam: ?*const anyopaque,
+) callconv(.C) void = undefined;
+pub var getDebugMessageLog: *const fn (
+    count: Uint,
+    bufSize: Sizei,
+    sources: [*c]Enum,
+    types: [*c]Enum,
+    ids: [*c]Uint,
+    severities: [*c]Enum,
+    lengths: [*c]Sizei,
+    messageLog: [*c]Char,
+) callconv(.C) Uint = undefined;
+pub var getPointerv: *const fn (
+    pname: Enum,
+    params: *anyopaque,
+) callconv(.C) void = undefined;
+pub var pushDebugGroup: *const fn (
+    source: Enum,
+    id: Uint,
+    length: Sizei,
+    message: [*c]const Char,
+) callconv(.C) void = undefined;
+pub var popDebugGroup: *const fn () callconv(.C) void = undefined;
+pub var objectLabel: *const fn (
+    identifier: Enum,
+    name: Uint,
+    length: Sizei,
+    label: [*c]const Char,
+) callconv(.C) void = undefined;
+pub var getObjectLabel: *const fn (
+    identifier: Enum,
+    name: Uint,
+    bufSize: Sizei,
+    length: *Sizei,
+    label: [*c]Char,
+) callconv(.C) void = undefined;
+pub var objectPtrLabel: *const fn (
+    ptr: *anyopaque,
+    length: Sizei,
+    label: [*c]const Char,
+) callconv(.C) void = undefined;
+pub var getObjectPtrLabel: *const fn (
+    ptr: *anyopaque,
+    bufSize: Sizei,
+    length: *Sizei,
+    label: [*c]Char,
+) callconv(.C) void = undefined;
+
 //--------------------------------------------------------------------------------------------------
 //
 // OpenGL 4.4 (Core Profile)
@@ -2167,3 +2249,72 @@ pub var deleteVertexArraysOES: *const fn (
 pub var genVertexArraysOES: *const fn (n: Sizei, arrays: [*c]Uint) callconv(.C) void = undefined;
 pub var isVertexArrayOES: *const fn (array: Uint) callconv(.C) Boolean = undefined;
 //--------------------------------------------------------------------------------------------------
+//
+// KHR_debug (OpenGL ES Extension #118)
+//
+//--------------------------------------------------------------------------------------------------
+pub var debugMessageControlKHR: *const fn (
+    source: Enum,
+    type: Enum,
+    severity: Enum,
+    count: Sizei,
+    ids: [*c]const Uint,
+    enabled: Boolean,
+) callconv(.C) void = undefined;
+pub var debugMessageInsertKHR: *const fn (
+    source: Enum,
+    type: Enum,
+    id: Uint,
+    severity: Enum,
+    length: Sizei,
+    buf: [*c]const u8,
+) callconv(.C) void = undefined;
+pub var debugMessageCallbackKHR: *const fn (
+    callback: DEBUGPROC,
+    userParam: ?*const anyopaque,
+) callconv(.C) void = undefined;
+pub var getDebugMessageLogKHR: *const fn (
+    count: Uint,
+    bufSize: Sizei,
+    sources: [*c]Enum,
+    types: [*c]Enum,
+    ids: [*c]Uint,
+    severities: [*c]Enum,
+    lengths: [*c]Sizei,
+    messageLog: [*c]Char,
+) callconv(.C) Uint = undefined;
+pub var getPointervKHR: *const fn (
+    pname: Enum,
+    params: *anyopaque,
+) callconv(.C) void = undefined;
+pub var pushDebugGroupKHR: *const fn (
+    source: Enum,
+    id: Uint,
+    length: Sizei,
+    message: [*c]const Char,
+) callconv(.C) void = undefined;
+pub var popDebugGroupKHR: *const fn () callconv(.C) void = undefined;
+pub var objectLabelKHR: *const fn (
+    identifier: Enum,
+    name: Uint,
+    length: Sizei,
+    label: [*c]const Char,
+) callconv(.C) void = undefined;
+pub var getObjectLabelKHR: *const fn (
+    identifier: Enum,
+    name: Uint,
+    bufSize: Sizei,
+    length: *Sizei,
+    label: [*c]Char,
+) callconv(.C) void = undefined;
+pub var objectPtrLabelKHR: *const fn (
+    ptr: *anyopaque,
+    length: Sizei,
+    label: [*c]const Char,
+) callconv(.C) void = undefined;
+pub var getObjectPtrLabelKHR: *const fn (
+    ptr: *anyopaque,
+    bufSize: Sizei,
+    length: *Sizei,
+    label: [*c]Char,
+) callconv(.C) void = undefined;

--- a/libs/zopengl/src/bindings.zig
+++ b/libs/zopengl/src/bindings.zig
@@ -2002,6 +2002,25 @@ pub const DEBUGPROC = *const fn (
     message: [*c]const Char,
     userParam: *const anyopaque,
 ) void;
+pub const DEBUG_SOURCE_API = 0x8246;
+pub const DEBUG_SOURCE_WINDOW_SYSTEM = 0x8247;
+pub const DEBUG_SOURCE_SHADER_COMPILER = 0x8248;
+pub const DEBUG_SOURCE_THIRD_PARTY = 0x8249;
+pub const DEBUG_SOURCE_APPLICATION = 0x824A;
+pub const DEBUG_SOURCE_OTHER = 0x824B;
+pub const DEBUG_TYPE_ERROR = 0x824C;
+pub const DEBUG_TYPE_DEPRECATED_BEHAVIOR = 0x824D;
+pub const DEBUG_TYPE_UNDEFINED_BEHAVIOR = 0x824E;
+pub const DEBUG_TYPE_PORTABILITY = 0x824F;
+pub const DEBUG_TYPE_PERFORMANCE = 0x8250;
+pub const DEBUG_TYPE_MARKER = 0x8268;
+pub const DEBUG_TYPE_PUSH_GROUP = 0x8269;
+pub const DEBUG_TYPE_POP_GROUP = 0x826A;
+pub const DEBUG_TYPE_OTHER = 0x8251;
+pub const DEBUG_SEVERITY_HIGH = 0x9146;
+pub const DEBUG_SEVERITY_MEDIUM = 0x9147;
+pub const DEBUG_SEVERITY_LOW = 0x9148;
+pub const DEBUG_SEVERITY_NOTIFICATION = 0x826B;
 
 pub var debugMessageControl: *const fn (
     source: Enum,

--- a/libs/zopengl/src/wrapper.zig
+++ b/libs/zopengl/src/wrapper.zig
@@ -255,6 +255,7 @@ pub const ParameterName = enum(Enum) {
     transform_feedback_buffer_binding = TRANSFORM_FEEDBACK_BUFFER_BINDING,
     transform_feedback_buffer_size = TRANSFORM_FEEDBACK_BUFFER_SIZE,
     transform_feedback_buffer_start = TRANSFORM_FEEDBACK_BUFFER_START,
+    vertex_array_binding = VERTEX_ARRAY_BINDING,
     read_framebuffer_binding = READ_FRAMEBUFFER_BINDING,
     renderbuffer_binding = RENDERBUFFER_BINDING,
     min_program_texel_offset = MIN_PROGRAM_TEXEL_OFFSET,
@@ -3275,36 +3276,7 @@ pub const FRAMEBUFFER_INCOMPLETE_DIMENSIONS = bindings.FRAMEBUFFER_INCOMPLETE_DI
 
 //--------------------------------------------------------------------------------------------------
 //
-// OES_vertex_array_object (OpenGL ES Extension #71)
+// OES_vertex_array_object
 //
 //--------------------------------------------------------------------------------------------------
-pub const VERTEX_ARRAY_BINDING_OES = bindings.VERTEX_ARRAY_BINDING_OES; // TODO: This is a pname accepted by getBoolean, getFloat and getInteger
-
-// pub var bindVertexArrayOES: *const fn (array: Uint) callconv(.C) void = undefined;
-pub fn bindVertexArrayOES(array: VertexArrayObject) void {
-    bindings.bindVertexArrayOES(@bitCast(Uint, array));
-}
-
-// pub var deleteVertexArraysOES: *const fn (
-//     n: Sizei,
-//     arrays: [*c]const Uint,
-// ) callconv(.C) void = undefined;
-pub fn deleteVertexArrayOES(ptr: *const VertexArrayObject) void {
-    bindings.deleteVertexArraysOES(1, @ptrCast([*c]Uint, ptr));
-}
-pub fn deleteVertexArraysOES(arrays: []const VertexArrayObject) void {
-    bindings.deleteVertexArraysOES(arrays.len, @ptrCast([*c]Uint, arrays.ptr));
-}
-
-// pub var genVertexArraysOES: *const fn (n: Sizei, arrays: [*c]Uint) callconv(.C) void = undefined;
-pub fn genVertexArrayOES(ptr: *VertexArrayObject) void {
-    bindings.genVertexArraysOES(1, @ptrCast([*c]Uint, ptr));
-}
-pub fn genVertexArraysOES(arrays: []VertexArrayObject) void {
-    bindings.genVertexArraysOES(arrays.len, @ptrCast([*c]Uint, arrays.ptr));
-}
-
-// pub var isVertexArrayOES: *const fn (array: Uint) callconv(.C) Boolean = undefined;
-pub fn isVertexArrayOES(array: VertexArrayObject) bool {
-    return bindings.isVertexArrayOES(@bitCast(Uint, array)) == TRUE;
-}
+pub const VERTEX_ARRAY_BINDING_OES = bindings.VERTEX_ARRAY_BINDING_OES;

--- a/libs/zopengl/src/wrapper.zig
+++ b/libs/zopengl/src/wrapper.zig
@@ -829,6 +829,47 @@ pub const PrimitiveType = enum(Enum) {
     triangles_adjacency = TRIANGLES_ADJACENCY,
 };
 
+pub const DebugSource = enum(Enum) {
+    //----------------------------------------------------------------------------------------------
+    // OpenGL 4.3 (Core Profile)
+    //----------------------------------------------------------------------------------------------
+    api = DEBUG_SOURCE_API,
+    window_system = DEBUG_SOURCE_WINDOW_SYSTEM,
+    shader_compiler = DEBUG_SOURCE_SHADER_COMPILER,
+    third_party = DEBUG_SOURCE_THIRD_PARTY,
+    application = DEBUG_SOURCE_APPLICATION,
+    other = DEBUG_SOURCE_OTHER,
+};
+
+pub const DebugType = enum(Enum) {
+    //----------------------------------------------------------------------------------------------
+    // OpenGL 4.3 (Core Profile)
+    //----------------------------------------------------------------------------------------------
+    @"error" = DEBUG_TYPE_ERROR,
+    deprecated_behavior = DEBUG_TYPE_DEPRECATED_BEHAVIOR,
+    undefined_behavior = DEBUG_TYPE_UNDEFINED_BEHAVIOR,
+    portability = DEBUG_TYPE_PORTABILITY,
+    performance = DEBUG_TYPE_PERFORMANCE,
+    marker = DEBUG_TYPE_MARKER,
+    push_group = DEBUG_TYPE_PUSH_GROUP,
+    pop_group = DEBUG_TYPE_POP_GROUP,
+    other = DEBUG_TYPE_OTHER,
+    debug_severity_high = DEBUG_SEVERITY_HIGH,
+    debug_severity_medium = DEBUG_SEVERITY_MEDIUM,
+    debug_severity_low = DEBUG_SEVERITY_LOW,
+    debug_severity_notification = DEBUG_SEVERITY_NOTIFICATION,
+};
+
+pub const DebugSeverity = enum(Enum) {
+    //----------------------------------------------------------------------------------------------
+    // OpenGL 4.3 (Core Profile)
+    //----------------------------------------------------------------------------------------------
+    high = DEBUG_SEVERITY_HIGH,
+    medium = DEBUG_SEVERITY_MEDIUM,
+    low = DEBUG_SEVERITY_LOW,
+    notification = DEBUG_SEVERITY_NOTIFICATION,
+};
+
 //--------------------------------------------------------------------------------------------------
 //
 // OpenGL 1.0 (Core Profile)
@@ -3257,6 +3298,114 @@ pub const INT_2_10_10_10_REV = bindings.INT_2_10_10_10_REV;
 //     type: Enum,
 //     normalized: Boolean,
 //     value: [*c]const Uint,
+// ) callconv(.C) void = undefined;
+
+//--------------------------------------------------------------------------------------------------
+//
+// OpenGL 4.3 (Core Profile)
+//
+//--------------------------------------------------------------------------------------------------
+pub const DEBUGPROC = *const fn (
+    source: DebugSource,
+    type: DebugType,
+    id: Uint,
+    severity: DebugSeverity,
+    length: u32,
+    message: [*]const u8,
+    userParam: ?*const anyopaque,
+) void;
+pub const DEBUG_SOURCE_API = bindings.DEBUG_SOURCE_API;
+pub const DEBUG_SOURCE_WINDOW_SYSTEM = bindings.DEBUG_SOURCE_WINDOW_SYSTEM;
+pub const DEBUG_SOURCE_SHADER_COMPILER = bindings.DEBUG_SOURCE_SHADER_COMPILER;
+pub const DEBUG_SOURCE_THIRD_PARTY = bindings.DEBUG_SOURCE_THIRD_PARTY;
+pub const DEBUG_SOURCE_APPLICATION = bindings.DEBUG_SOURCE_APPLICATION;
+pub const DEBUG_SOURCE_OTHER = bindings.DEBUG_SOURCE_OTHER;
+pub const DEBUG_TYPE_ERROR = bindings.DEBUG_TYPE_ERROR;
+pub const DEBUG_TYPE_DEPRECATED_BEHAVIOR = bindings.DEBUG_TYPE_DEPRECATED_BEHAVIOR;
+pub const DEBUG_TYPE_UNDEFINED_BEHAVIOR = bindings.DEBUG_TYPE_UNDEFINED_BEHAVIOR;
+pub const DEBUG_TYPE_PORTABILITY = bindings.DEBUG_TYPE_PORTABILITY;
+pub const DEBUG_TYPE_PERFORMANCE = bindings.DEBUG_TYPE_PERFORMANCE;
+pub const DEBUG_TYPE_MARKER = bindings.DEBUG_TYPE_MARKER;
+pub const DEBUG_TYPE_PUSH_GROUP = bindings.DEBUG_TYPE_PUSH_GROUP;
+pub const DEBUG_TYPE_POP_GROUP = bindings.DEBUG_TYPE_POP_GROUP;
+pub const DEBUG_TYPE_OTHER = bindings.DEBUG_TYPE_OTHER;
+pub const DEBUG_SEVERITY_HIGH = bindings.DEBUG_SEVERITY_HIGH;
+pub const DEBUG_SEVERITY_MEDIUM = bindings.DEBUG_SEVERITY_MEDIUM;
+pub const DEBUG_SEVERITY_LOW = bindings.DEBUG_SEVERITY_LOW;
+pub const DEBUG_SEVERITY_NOTIFICATION = bindings.DEBUG_SEVERITY_NOTIFICATION;
+
+// pub var debugMessageControl: *const fn (
+//     source: Enum,
+//     type: Enum,
+//     severity: Enum,
+//     count: Sizei,
+//     ids: [*c]const Uint,
+//     enabled: Boolean,
+// ) callconv(.C) void = undefined;
+// pub var debugMessageInsert: *const fn (
+//     source: Enum,
+//     type: Enum,
+//     id: Uint,
+//     severity: Enum,
+//     length: Sizei,
+//     buf: [*c]const u8,
+// ) callconv(.C) void = undefined;
+
+// pub var debugMessageCallback: *const fn (
+//     callback: DEBUGPROC,
+//     userParam: ?*const anyopaque,
+// ) callconv(.C) void = undefined;
+pub fn debugMessageCallback(
+    callback: DEBUGPROC,
+    userParam: ?*const anyopaque,
+) void {
+    bindings.debugMessageCallback(@ptrCast(bindings.DEBUGPROC, callback), userParam);
+}
+
+// pub var getDebugMessageLog: *const fn (
+//     count: Uint,
+//     bufSize: Sizei,
+//     sources: [*c]Enum,
+//     types: [*c]Enum,
+//     ids: [*c]Uint,
+//     severities: [*c]Enum,
+//     lengths: [*c]Sizei,
+//     messageLog: [*c]Char,
+// ) callconv(.C) Uint = undefined;
+// pub var getPointerv: *const fn (
+//     pname: Enum,
+//     params: [*c][*c]anyopaque,
+// ) callconv(.C) void = undefined;
+// pub var pushDebugGroup: *const fn (
+//     source: Enum,
+//     id: Uint,
+//     length: Sizei,
+//     message: [*c]const Char,
+// ) callconv(.C) void = undefined;
+// pub var popDebugGroup: *const fn () callconv(.C) void = undefined;
+// pub var objectLabel: *const fn (
+//     identifier: Enum,
+//     name: Uint,
+//     length: Sizei,
+//     label: [*c]const Char,
+// ) callconv(.C) void = undefined;
+// pub var getObjectLabel: *const fn (
+//     identifier: Enum,
+//     name: Uint,
+//     bufSize: Sizei,
+//     length: *Sizei,
+//     label: [*c]Char,
+// ) callconv(.C) void = undefined;
+// pub var objectPtrLabel: *const fn (
+//     ptr: *anyopaque,
+//     length: Sizei,
+//     label: [*c]const Char,
+// ) callconv(.C) void = undefined;
+// pub var getObjectPtrLabel: *const fn (
+//     ptr: *anyopaque,
+//     bufSize: Sizei,
+//     length: *Sizei,
+//     label: [*c]Char,
 // ) callconv(.C) void = undefined;
 
 //--------------------------------------------------------------------------------------------------

--- a/libs/zopengl/src/zopengl.zig
+++ b/libs/zopengl/src/zopengl.zig
@@ -17,9 +17,14 @@ pub usingnamespace switch (options.api) {
 pub const LoaderFn = *const fn ([:0]const u8) ?*const anyopaque;
 
 pub const Extension = enum {
-    OES_vertex_array_object,
+    KHR_debug,
     NV_bindless_texture,
     NV_shader_buffer_load,
+};
+
+pub const EsExtension = enum {
+    OES_vertex_array_object,
+    KHR_debug,
 };
 
 pub fn loadCoreProfile(loader: LoaderFn, major: u32, minor: u32) !void {
@@ -692,6 +697,17 @@ pub fn loadCoreProfile(loader: LoaderFn, major: u32, minor: u32) !void {
 
     // OpenGL 4.3
     if (ver >= 43) {
+        bindings.debugMessageControl = try getProcAddress(@TypeOf(bindings.debugMessageControl), "glDebugMessageControl");
+        bindings.debugMessageInsert = try getProcAddress(@TypeOf(bindings.debugMessageInsert), "glDebugMessageInsert");
+        bindings.debugMessageCallback = try getProcAddress(@TypeOf(bindings.debugMessageCallback), "glDebugMessageCallback");
+        bindings.getDebugMessageLog = try getProcAddress(@TypeOf(bindings.getDebugMessageLog), "glGetDebugMessageLog");
+        bindings.getPointerv = try getProcAddress(@TypeOf(bindings.getPointerv), "glGetPointerv");
+        bindings.pushDebugGroup = try getProcAddress(@TypeOf(bindings.pushDebugGroup), "glPushDebugGroup");
+        bindings.popDebugGroup = try getProcAddress(@TypeOf(bindings.popDebugGroup), "glPopDebugGroup");
+        bindings.objectLabel = try getProcAddress(@TypeOf(bindings.objectLabel), "glObjectLabel");
+        bindings.getObjectLabel = try getProcAddress(@TypeOf(bindings.getObjectLabel), "glGetObjectLabel");
+        bindings.objectPtrLabel = try getProcAddress(@TypeOf(bindings.objectPtrLabel), "glObjectPtrLabel");
+        bindings.getObjectPtrLabel = try getProcAddress(@TypeOf(bindings.getObjectPtrLabel), "glGetObjectPtrLabel");
         // TODO
     }
 
@@ -1174,22 +1190,50 @@ pub fn loadExtension(loader: LoaderFn, extension: Extension) !void {
     loaderFunc = loader;
 
     switch (extension) {
-        .OES_vertex_array_object => {
-            bindings.bindVertexArrayOES = try getProcAddress(
-                @TypeOf(bindings.bindVertexArrayOES),
-                "glBindVertexArrayOES",
+        .KHR_debug => {
+            bindings.debugMessageControl = try getProcAddress(
+                @TypeOf(bindings.debugMessageControl),
+                "glDebugMessageControl",
             );
-            bindings.deleteVertexArraysOES = try getProcAddress(
-                @TypeOf(bindings.deleteVertexArraysOES),
-                "glDeleteVertexArraysOES",
+            bindings.debugMessageInsert = try getProcAddress(
+                @TypeOf(bindings.debugMessageInsert),
+                "glDebugMessageInsert",
             );
-            bindings.genVertexArraysOES = try getProcAddress(
-                @TypeOf(bindings.genVertexArraysOES),
-                "glGenVertexArraysOES",
+            bindings.debugMessageCallback = try getProcAddress(
+                @TypeOf(bindings.debugMessageCallback),
+                "glDebugMessageCallback",
             );
-            bindings.isVertexArrayOES = try getProcAddress(
-                @TypeOf(bindings.isVertexArrayOES),
-                "glIsVertexArrayOES",
+            bindings.getDebugMessageLog = try getProcAddress(
+                @TypeOf(bindings.getDebugMessageLog),
+                "glGetDebugMessageLog",
+            );
+            bindings.getPointerv = try getProcAddress(
+                @TypeOf(bindings.getPointerv),
+                "glGetPointerv",
+            );
+            bindings.pushDebugGroup = try getProcAddress(
+                @TypeOf(bindings.pushDebugGroup),
+                "glPushDebugGroup",
+            );
+            bindings.popDebugGroup = try getProcAddress(
+                @TypeOf(bindings.popDebugGroup),
+                "glPopDebugGroup",
+            );
+            bindings.objectLabel = try getProcAddress(
+                @TypeOf(bindings.objectLabel),
+                "glObjectLabel",
+            );
+            bindings.getObjectLabel = try getProcAddress(
+                @TypeOf(bindings.getObjectLabel),
+                "glGetObjectLabel",
+            );
+            bindings.objectPtrLabel = try getProcAddress(
+                @TypeOf(bindings.objectPtrLabel),
+                "glObjectPtrLabel",
+            );
+            bindings.getObjectPtrLabel = try getProcAddress(
+                @TypeOf(bindings.getObjectPtrLabel),
+                "glGetObjectPtrLabel",
             );
         },
         .NV_bindless_texture => {
@@ -1222,6 +1266,90 @@ pub fn loadExtension(loader: LoaderFn, extension: Extension) !void {
         },
     }
 }
+
+pub fn loadEsExtension(loader: LoaderFn, extension: EsExtension) !void {
+    loaderFunc = loader;
+
+    switch (extension) {
+        .KHR_debug => {
+            try bind("glDebugMessageControlKHR", .{
+                &bindings.debugMessageControl,
+                &bindings.debugMessageControlKHR,
+            });
+            try bind("glDebugMessageInsertKHR", .{
+                &bindings.debugMessageInsert,
+                &bindings.debugMessageInsertKHR,
+            });
+            try bind("glDebugMessageCallbackKHR", .{
+                &bindings.debugMessageCallback,
+                &bindings.debugMessageCallbackKHR,
+            });
+            try bind("glGetDebugMessageLogKHR", .{
+                &bindings.getDebugMessageLog,
+                &bindings.getDebugMessageLogKHR,
+            });
+            try bind("glGetPointervKHR", .{
+                &bindings.getPointerv,
+                &bindings.getPointervKHR,
+            });
+            try bind("glPushDebugGroupKHR", .{
+                &bindings.pushDebugGroup,
+                &bindings.pushDebugGroupKHR,
+            });
+            try bind("glPopDebugGroupKHR", .{
+                &bindings.popDebugGroup,
+                &bindings.popDebugGroupKHR,
+            });
+            try bind("glObjectLabelKHR", .{
+                &bindings.objectLabel,
+                &bindings.objectLabelKHR,
+            });
+            try bind("glGetObjectLabelKHR", .{
+                &bindings.getObjectLabel,
+                &bindings.getObjectLabelKHR,
+            });
+            try bind("glObjectPtrLabelKHR", .{
+                &bindings.objectPtrLabel,
+                &bindings.objectPtrLabelKHR,
+            });
+            try bind("glGetObjectPtrLabelKHR", .{
+                &bindings.getObjectPtrLabel,
+                &bindings.getObjectPtrLabelKHR,
+            });
+        },
+        .OES_vertex_array_object => {
+            try bind("glBindVertexArrayOES", .{
+                &bindings.bindVertexArray,
+                &bindings.bindVertexArrayOES,
+            });
+            try bind("glDeleteVertexArraysOES", .{
+                &bindings.deleteVertexArrays,
+                &bindings.deleteVertexArraysOES,
+            });
+            try bind("glGenVertexArraysOES", .{
+                &bindings.genVertexArrays,
+                &bindings.genVertexArraysOES,
+            });
+            try bind("glIsVertexArrayOES", .{
+                &bindings.isVertexArray,
+                &bindings.isVertexArrayOES,
+            });
+        },
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+fn bind(gl_proc_name: [:0]const u8, bind_addresses: anytype) !void {
+    const ProcType = @typeInfo(@TypeOf(bind_addresses.@"0")).Pointer.child;
+    const proc = try getProcAddress(ProcType, gl_proc_name);
+    inline for (bind_addresses) |bind_addr| {
+        if (@typeInfo(@TypeOf(bind_addr)).Pointer.child != ProcType) {
+            @compileError("proc bindings should all be the same type");
+        }
+        bind_addr.* = proc;
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 var loaderFunc: LoaderFn = undefined;
 


### PR DESCRIPTION
Bindings:
- Define core 4.3 debug api & KHR_debug
- Separate ES extension enum from "desktop" extension enum
- Introduce bind util fn for binding gl procs to multiple symbols. This is useful for binding ES flavoured proc names to their "desktop" equivalent for convenience of programmer writing cross-platform gl

Wrapper:
- Define `DebugSource`, `DebugType` and `DebugSeverity` enums
- Wrap `debugMessageCallback`
- Remove superfluous ES flavour from wrapper; wrapper uses aliased bindings where appropriate
- Add `vertex_array_binding` to `ParameterName` enum