### PR TITLE
Fix memory leak in zaudio sample code

### DIFF
--- a/libs/zaudio/README.md
+++ b/libs/zaudio/README.md
@@ -66,11 +66,13 @@ pub fn main() !void {
     defer zaudio.deinit();
 
     const engine = try zaudio.Engine.create(null);
+    defer engine.destroy();
 
     const music = try engine.createSoundFromFile(
         content_dir ++ "Broke For Free - Night Owl.mp3",
         .{ .flags = .{ .stream = true } },
     );
+    defer music.destroy();
     try music.start();
     ...
 }


### PR DESCRIPTION
Beforehand neither `engine.destroy()` or `music.destroy()` was called, this fixes that, so now this sample code runs and exits cleanly