### PR TITLE
zpool: Fix incorrect error set in requireLiveHandle

### DIFF
--- a/libs/zpool/src/pool.zig
+++ b/libs/zpool/src/pool.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 
-pub const PoolError = error{
-    PoolIsFull,
+pub const PoolError = error{PoolIsFull} || HandleError;
+
+pub const HandleError = error{
     HandleIsUnacquired,
     HandleIsOutOfBounds,
     HandleIsReleased,
@@ -186,12 +187,9 @@ pub fn Pool(
             return self.isLiveAddressableHandle(handle.addressable());
         }
 
-        /// Checks whether `handle` is live, otherwise returns one of:
-        /// * `Error.HandleIsUnacquired`
-        /// * `Error.HandleIsOutOfBounds`
-        /// * `Error.HandleIsReleased`
+        /// Checks whether `handle` is live.
         /// Unlike `std.debug.assert()`, this check is evaluated in all builds.
-        pub fn requireLiveHandle(self: Self, handle: Handle) !void {
+        pub fn requireLiveHandle(self: Self, handle: Handle) HandleError!void {
             try self.requireLiveAddressableHandle(handle.addressable());
         }
 
@@ -287,12 +285,8 @@ pub fn Pool(
             return ahandle.handle();
         }
 
-        /// Removes (and invalidates) `handle` if live, otherwise returns one
-        /// of:
-        /// * `Error.HandleIsUnacquired`
-        /// * `Error.HandleIsOutOfBounds`
-        /// * `Error.HandleIsReleased`
-        pub fn remove(self: *Self, handle: Handle) !void {
+        /// Removes (and invalidates) `handle` if live.
+        pub fn remove(self: *Self, handle: Handle) HandleError!void {
             try self.releaseAddressableHandle(handle.addressable());
         }
 
@@ -317,51 +311,36 @@ pub fn Pool(
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-        /// Gets a column pointer if `handle` is live, otherwise returns one of:
-        /// * `Error.HandleIsUnacquired`
-        /// * `Error.HandleIsOutOfBounds`
-        /// * `Error.HandleIsReleased`
-        pub fn getColumnPtr(self: Self, handle: Handle, comptime column: Column) !*ColumnType(column) {
+        /// Gets a column pointer if `handle` is live.
+        pub fn getColumnPtr(self: Self, handle: Handle, comptime column: Column) HandleError!*ColumnType(column) {
             const ahandle = handle.addressable();
             try self.requireLiveAddressableHandle(ahandle);
             return self.getColumnPtrUnchecked(ahandle, column);
         }
 
-        /// Gets a column value if `handle` is live, otherwise returns one of:
-        /// * `Error.HandleIsUnacquired`
-        /// * `Error.HandleIsOutOfBounds`
-        /// * `Error.HandleIsReleased`
-        pub fn getColumn(self: Self, handle: Handle, comptime column: Column) !ColumnType(column) {
+        /// Gets a column value if `handle` is live.
+        pub fn getColumn(self: Self, handle: Handle, comptime column: Column) HandleError!ColumnType(column) {
             const ahandle = handle.addressable();
             try self.requireLiveAddressableHandle(ahandle);
             return self.getColumnUnchecked(ahandle, column);
         }
 
-        /// Gets column values if `handle` is live, otherwise returns one of:
-        /// * `Error.HandleIsUnacquired`
-        /// * `Error.HandleIsOutOfBounds`
-        /// * `Error.HandleIsReleased`
-        pub fn getColumns(self: Self, handle: Handle) !Columns {
+        /// Gets column values if `handle` is live.
+        pub fn getColumns(self: Self, handle: Handle) HandleError!Columns {
             const ahandle = handle.addressable();
             try self.requireLiveAddressableHandle(ahandle);
             return self.getColumnsUnchecked(ahandle);
         }
 
-        /// Sets a column value if `handle` is live, otherwise returns one of:
-        /// * `Error.HandleIsUnacquired`
-        /// * `Error.HandleIsOutOfBounds`
-        /// * `Error.HandleIsReleased`
-        pub fn setColumn(self: Self, handle: Handle, comptime column: Column, value: ColumnType(column)) !void {
+        /// Sets a column value if `handle` is live.
+        pub fn setColumn(self: Self, handle: Handle, comptime column: Column, value: ColumnType(column)) HandleError!void {
             const ahandle = handle.addressable();
             try self.requireLiveAddressableHandle(ahandle);
             self.setColumnUnchecked(ahandle, column, value);
         }
 
-        /// Sets column values if `handle` is live, otherwise returns one of:
-        /// * `Error.HandleIsUnacquired`
-        /// * `Error.HandleIsOutOfBounds`
-        /// * `Error.HandleIsReleased`
-        pub fn setColumns(self: Self, handle: Handle, values: Columns) !void {
+        /// Sets column values if `handle` is live.
+        pub fn setColumns(self: Self, handle: Handle, values: Columns) HandleError!void {
             const ahandle = handle.addressable();
             try self.requireLiveAddressableHandle(ahandle);
             self.setColumnsUnchecked(ahandle, values);
@@ -566,7 +545,7 @@ pub fn Pool(
         fn requireLiveAddressableHandle(
             self: Self,
             handle: AddressableHandle,
-        ) !void {
+        ) HandleError!void {
             if (isFreeCycle(handle.cycle))
                 return error.HandleIsUnacquired;
             if (handle.index >= self._curr_cycle.len)

--- a/libs/zpool/src/pool.zig
+++ b/libs/zpool/src/pool.zig
@@ -191,7 +191,7 @@ pub fn Pool(
         /// * `Error.HandleIsOutOfBounds`
         /// * `Error.HandleIsReleased`
         /// Unlike `std.debug.assert()`, this check is evaluated in all builds.
-        pub fn requireLiveHandle(self: Self, handle: Handle) Error!void {
+        pub fn requireLiveHandle(self: Self, handle: Handle) !void {
             try self.requireLiveAddressableHandle(handle.addressable());
         }
 
@@ -566,13 +566,13 @@ pub fn Pool(
         fn requireLiveAddressableHandle(
             self: Self,
             handle: AddressableHandle,
-        ) Error!void {
+        ) !void {
             if (isFreeCycle(handle.cycle))
-                return Error.HandleIsUnacquired;
+                return error.HandleIsUnacquired;
             if (handle.index >= self._curr_cycle.len)
-                return Error.HandleIsOutOfBounds;
+                return error.HandleIsOutOfBounds;
             if (handle.cycle != self._curr_cycle[handle.index])
-                return Error.HandleIsReleased;
+                return error.HandleIsReleased;
         }
 
         fn acquireAddressableHandle(self: *Self) !AddressableHandle {

--- a/libs/zpool/src/pool.zig
+++ b/libs/zpool/src/pool.zig
@@ -547,11 +547,11 @@ pub fn Pool(
             handle: AddressableHandle,
         ) HandleError!void {
             if (isFreeCycle(handle.cycle))
-                return error.HandleIsUnacquired;
+                return Error.HandleIsUnacquired;
             if (handle.index >= self._curr_cycle.len)
-                return error.HandleIsOutOfBounds;
+                return Error.HandleIsOutOfBounds;
             if (handle.cycle != self._curr_cycle[handle.index])
-                return error.HandleIsReleased;
+                return Error.HandleIsReleased;
         }
 
         fn acquireAddressableHandle(self: *Self) !AddressableHandle {


### PR DESCRIPTION
I noticed that `requireLiveHandle` (as well as `getColumns` and probably more) could return `error.PoolIsFull`. I switched from the explicit `Error!...` to an implicit error set to fix this.

I also see that the possible errors are listed in the documentation, but maybe it would be better to remove those and use an explicit error set (one that doesn't include `error.PoolIsFull`). Then `Error` could be defined as, for example, `error{PoolIsFull} || HandleError`. Let me know if you'd prefer that solution and I can update this PR :)