### PR TITLE
zflecs: correct typo in readme

### DIFF
--- a/libs/zflecs/README.md
+++ b/libs/zflecs/README.md
@@ -8,7 +8,7 @@ Then in your `build.zig` add:
 
 ```zig
 const std = @import("std");
-const zsdl = @import("libs/zflecs/build.zig");
+const zflecs = @import("libs/zflecs/build.zig");
 
 pub fn build(b: *std.Build) void {
     ...


### PR DESCRIPTION
The README in `zflecs` seems to have an artifact from the previous `zsdl` README; this PR corrects that to the proper library.