### PR TITLE
zglfw: add setClipboardString, getClipboardString, and setDropCallback

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -596,6 +596,15 @@ pub const Window = opaque {
     }
     extern fn glfwSetWindowTitle(window: *Window, title: [*:0]const u8) void;
 
+    pub const getClipboardString = glfwGetClipboardString;
+    extern fn glfwGetClipboardString(window: *Window) ?[*:0]const u8;
+
+    pub const setClipboardString = glfwSetClipboardString;
+    extern fn glfwSetClipboardString(
+        window: *Window,
+        string: [*:0]const u8,
+    ) void;
+
     /// `pub fn setFramebufferSizeCallback(window: *Window, callback) void`
     pub const setFramebufferSizeCallback = glfwSetFramebufferSizeCallback;
     extern fn glfwSetFramebufferSizeCallback(window: *Window, callback: ?*const fn (
@@ -647,6 +656,17 @@ pub const Window = opaque {
             scancode: i32,
             action: Action,
             mods: Mods,
+        ) callconv(.C) void,
+    ) void;
+
+    /// `pub fn setDropCallback(window: *Window, callback) void`
+    pub const setDropCallback = glfwSetDropCallback;
+    extern fn glfwSetDropCallback(
+        window: *Window,
+        callback: ?*const fn (
+            window: *Window,
+            path_count: i32,
+            paths: [*][*:0]const u8,
         ) callconv(.C) void,
     ) void;
 

--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -596,10 +596,14 @@ pub const Window = opaque {
     }
     extern fn glfwSetWindowTitle(window: *Window, title: [*:0]const u8) void;
 
-    pub const getClipboardString = glfwGetClipboardString;
+    pub fn getClipboardString(window: *Window) ?[:0]const u8 {
+        return std.mem.span(glfwGetClipboardString(window));
+    }
     extern fn glfwGetClipboardString(window: *Window) ?[*:0]const u8;
 
-    pub const setClipboardString = glfwSetClipboardString;
+    pub inline fn setClipboardString(window: *Window, string: [:0]const u8) void {
+        return glfwSetClipboardString(window, string);
+    }
     extern fn glfwSetClipboardString(
         window: *Window,
         string: [*:0]const u8,


### PR DESCRIPTION
i was unsure where to put the clipboard functions as they take a ``window`` parameter but glfw docs say that its deprecated and can also just take null. not familiar with the standard way of handling strings with extern C functions so ill gladly change something if needed.