### PR TITLE
zflecs: fix wrong alignment issue #284

### DIFF
--- a/libs/zflecs/build.zig
+++ b/libs/zflecs/build.zig
@@ -30,6 +30,7 @@ pub fn package(
     zflecs_c_cpp.addCSourceFile(thisDir() ++ "/libs/flecs/flecs.c", &.{
         "-fno-sanitize=undefined",
         "-DFLECS_NO_CPP",
+        "-DFLECS_USE_OS_ALLOC",
         if (@import("builtin").mode == .Debug) "-DFLECS_SANITIZE" else "",
     });
 

--- a/libs/zflecs/src/tests.zig
+++ b/libs/zflecs/src/tests.zig
@@ -278,22 +278,24 @@ test "zflecs.helloworld" {
     print("Bob's position is ({d}, {d})\n", .{ p.x, p.y });
 }
 
-test "zflecs.alignment" {
+test "zflecs.try_different_alignments" {
     const world = ecs.init();
     defer _ = ecs.fini(world);
 
-    const AlignmentsToTest = [_]usize{ 16, 32 };
-    inline for (AlignmentsToTest) |alignment| {
-        const Component = struct {
-            dummy: u32 align(alignment) = 0,
+    const AlignmentsToTest = [_]usize{ 8, 16, 32, 64, 128 };
+    inline for (AlignmentsToTest) |component_alignment| {
+        const AlignedComponent = struct {
+            fn Component(comptime alignment: usize) type {
+                return struct { dummy: u32 align(alignment) = 0 };
+            }
         };
+
+        const Component = AlignedComponent.Component(component_alignment);
 
         ecs.COMPONENT(world, Component);
         var entity = ecs.new_entity(world, "");
 
-        var component = Component{};
-        _ = ecs.set(world, entity, Component, component);
-
+        _ = ecs.set(world, entity, Component, .{});
         _ = ecs.get(world, entity, Component);
     }
 }

--- a/libs/zflecs/src/tests.zig
+++ b/libs/zflecs/src/tests.zig
@@ -277,3 +277,23 @@ test "zflecs.helloworld" {
     const p = ecs.get(world, bob, Position).?;
     print("Bob's position is ({d}, {d})\n", .{ p.x, p.y });
 }
+
+test "zflecs.alignment" {
+    const world = ecs.init();
+    defer _ = ecs.fini(world);
+
+    const AlignmentsToTest = [_]usize{ 16, 32 };
+    inline for (AlignmentsToTest) |alignment| {
+        const Component = struct {
+            dummy: u32 align(alignment) = 0,
+        };
+
+        ecs.COMPONENT(world, Component);
+        var entity = ecs.new_entity(world, "");
+
+        var component = Component{};
+        _ = ecs.set(world, entity, Component, component);
+
+        _ = ecs.get(world, entity, Component);
+    }
+}

--- a/libs/zflecs/src/tests.zig
+++ b/libs/zflecs/src/tests.zig
@@ -175,13 +175,22 @@ test "zflecs.basic" {
 
     ecs.TAG(world, Walking);
 
-    print("{s} id: {d}\n", .{ ecs.id_str(world, ecs.id(*const Position)).?, ecs.id(*const Position) });
-    print("{s} id: {d}\n", .{ ecs.id_str(world, ecs.id(?*const Position)).?, ecs.id(?*const Position) });
-    print("{s} id: {d}\n", .{ ecs.id_str(world, ecs.id(*Position)).?, ecs.id(*Position) });
-    print("{s} id: {d}\n", .{ ecs.id_str(world, ecs.id(Position)).?, ecs.id(Position) });
-    print("{s} id: {d}\n", .{ ecs.id_str(world, ecs.id(Direction)).?, ecs.id(Direction) });
-    print("{s} id: {d}\n", .{ ecs.id_str(world, ecs.id(Walking)).?, ecs.id(Walking) });
-    print("{s} id: {d}\n", .{ ecs.id_str(world, ecs.id(u31)).?, ecs.id(u31) });
+    const PrintIdHelper = struct {
+        fn printId(in_world: *ecs.world_t, comptime T: type) void {
+            var id_str = ecs.id_str(in_world, ecs.id(T)).?;
+            defer ecs.os.free(id_str);
+
+            print("{s} id: {d}\n", .{ id_str, ecs.id(T) });
+        }
+    };
+
+    PrintIdHelper.printId(world, *const Position);
+    PrintIdHelper.printId(world, ?*const Position);
+    PrintIdHelper.printId(world, *Position);
+    PrintIdHelper.printId(world, Position);
+    PrintIdHelper.printId(world, *Direction);
+    PrintIdHelper.printId(world, *Walking);
+    PrintIdHelper.printId(world, *u31);
 
     const p: Position = .{ .x = 1.0, .y = 2.0 };
     _ = ecs.set(world, e0, *const Position, &p);

--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -811,6 +811,94 @@ pub const world_info_t = extern struct {
     },
     name_prefix: [*:0]const u8,
 };
+
+const EcsAllocator = struct {
+    const AllocationHeader = struct {
+        size: usize,
+    };
+
+    const Alignment = 128;
+    const AllocationHeaderSize = Alignment;
+
+    var gpa: ?std.heap.GeneralPurposeAllocator(.{}) = null;
+    var allocator: ?std.mem.Allocator = null;
+
+    fn alloc(size: i32) callconv(.C) ?*anyopaque {
+        if (size < 0) {
+            return null;
+        }
+
+        var allocation_size = AllocationHeaderSize + @intCast(usize, size);
+
+        var data = allocator.?.alignedAlloc(u8, Alignment, allocation_size) catch {
+            return null;
+        };
+
+        var allocation_header = @ptrCast(
+            *AllocationHeader,
+            @alignCast(@alignOf(AllocationHeader), data.ptr),
+        );
+
+        allocation_header.size = allocation_size;
+
+        return data.ptr + AllocationHeaderSize;
+    }
+
+    fn free(ptr: ?*anyopaque) callconv(.C) void {
+        if (ptr == null) {
+            return;
+        }
+        var ptr_unwrapped = @ptrCast([*]u8, ptr.?) - AllocationHeaderSize;
+        var allocation_header = @ptrCast(
+            *AllocationHeader,
+            @alignCast(Alignment, ptr_unwrapped),
+        );
+
+        allocator.?.free(
+            @alignCast(
+                Alignment,
+                ptr_unwrapped[0..allocation_header.size],
+            ),
+        );
+    }
+
+    fn realloc(old: ?*anyopaque, size: i32) callconv(.C) ?*anyopaque {
+        if (old == null) {
+            return alloc(size);
+        }
+
+        var ptr_unwrapped = @ptrCast([*]u8, old.?) - AllocationHeaderSize;
+
+        var allocation_header = @ptrCast(
+            *AllocationHeader,
+            @alignCast(@alignOf(AllocationHeader), ptr_unwrapped),
+        );
+
+        const old_allocation_size = allocation_header.size;
+        const old_slice = @ptrCast([*]u8, ptr_unwrapped)[0..old_allocation_size];
+        const old_slice_aligned = @alignCast(Alignment, old_slice);
+
+        const new_allocation_size = AllocationHeaderSize + @intCast(usize, size);
+        var new_data = allocator.?.realloc(old_slice_aligned, new_allocation_size) catch {
+            return null;
+        };
+
+        var new_allocation_header = @ptrCast(*AllocationHeader, @alignCast(Alignment, new_data.ptr));
+        new_allocation_header.size = new_allocation_size;
+
+        return new_data.ptr + AllocationHeaderSize;
+    }
+
+    fn calloc(size: i32) callconv(.C) ?*anyopaque {
+        var data_maybe = alloc(size);
+        if (data_maybe) |data| {
+            @memset(@ptrCast([*]u8, data)[0..@intCast(usize, size)], 0);
+        }
+
+        return data_maybe;
+    }
+};
+
 //--------------------------------------------------------------------------------------------------
 //
 // Creation & Deletion
@@ -818,6 +906,17 @@ pub const world_info_t = extern struct {
 //--------------------------------------------------------------------------------------------------
 pub fn init() *world_t {
     assert(num_worlds == 0);
+
+    if (num_worlds == 0) {
+        EcsAllocator.gpa = .{};
+        EcsAllocator.allocator = EcsAllocator.gpa.?.allocator();
+
+        os.ecs_os_api.malloc_ = &EcsAllocator.alloc;
+        os.ecs_os_api.free_ = &EcsAllocator.free;
+        os.ecs_os_api.realloc_ = &EcsAllocator.realloc;
+        os.ecs_os_api.calloc_ = &EcsAllocator.calloc;
+    }
+
     num_worlds += 1;
     component_ids_hm.ensureTotalCapacity(32) catch @panic("OOM");
     const world = ecs_init();
@@ -884,7 +983,15 @@ pub fn fini(world: *world_t) i32 {
     }
     component_ids_hm.clearRetainingCapacity();
 
-    return ecs_fini(world);
+    var fini_result = ecs_fini(world);
+
+    if (num_worlds == 0) {
+        _ = EcsAllocator.gpa.?.deinit();
+        EcsAllocator.gpa = null;
+        EcsAllocator.allocator = null;
+    }
+
+    return fini_result;
 }
 extern fn ecs_fini(world: *world_t) i32;
 


### PR DESCRIPTION
[This](https://github.com/SanderMertens/flecs/issues/478.) is the flecs issue for reference.
Compiling flecs using ```-DFLECS_USE_OS_ALLOC``` already works around the issue. 

But I've also implemented the allocation related os calls using a gpa to track memory leaks and guarantee correct alignment. 
I haven't benchmarked the performance impact of using it. So it might make sense to make it optional 🤷.