### PR TITLE
zflecs: dump stacktrace when flecs calls abort

### DIFF
--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -813,6 +813,7 @@ pub const world_info_t = extern struct {
 };
 
 fn flecs_abort() callconv(.C) noreturn {
+    @breakpoint();
     std.debug.dumpCurrentStackTrace(@returnAddress());
     std.os.exit(1);
 }

--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -813,8 +813,8 @@ pub const world_info_t = extern struct {
 };
 
 fn flecs_abort() callconv(.C) noreturn {
-    @breakpoint();
     std.debug.dumpCurrentStackTrace(@returnAddress());
+    @breakpoint();
     std.os.exit(1);
 }
 

--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
+const builtin = @import("builtin");
 
 pub const ftime_t = f32;
 pub const size_t = i32;
@@ -824,7 +825,9 @@ fn flecs_abort() callconv(.C) noreturn {
 //
 //--------------------------------------------------------------------------------------------------
 pub fn init() *world_t {
-    os.ecs_os_api.abort_ = flecs_abort;
+    if (builtin.os.tag == .windows) {
+        os.ecs_os_api.abort_ = flecs_abort;
+    }
 
     assert(num_worlds == 0);
     num_worlds += 1;

--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -811,12 +811,20 @@ pub const world_info_t = extern struct {
     },
     name_prefix: [*:0]const u8,
 };
+
+fn flecs_abort() callconv(.C) noreturn {
+    std.debug.dumpCurrentStackTrace(@returnAddress());
+    std.os.exit(1);
+}
+
 //--------------------------------------------------------------------------------------------------
 //
 // Creation & Deletion
 //
 //--------------------------------------------------------------------------------------------------
 pub fn init() *world_t {
+    os.ecs_os_api.abort_ = flecs_abort;
+
     assert(num_worlds == 0);
     num_worlds += 1;
     component_ids_hm.ensureTotalCapacity(32) catch @panic("OOM");


### PR DESCRIPTION
When I first started integrating zflecs I had a difficult time tracking down some assertions. 
At the moment flecs internal assertions kill your application without hitting a breakpoint and don't give you any more info than what you see below.
```
D:\Projects\zig-gamedev\libs\zflecs>zig build test
run zflecs-tests: error: fatal: flecs.c: 8845: assert: entity != 0 INVALID_PARAMETER
run zflecs-tests: error: while executing test 'test.zflecs.do_something_wonky', the following command exited with code 3 (expected exited with code 0):
D:\Projects\zig-gamedev\libs\zflecs\zig-cache\o\6e293e5c127177595bffab996fe9a99a\zflecs-tests.exe --listen=-
Build Summary: 2/4 steps succeeded; 1 failed; 5/5 tests passed (disable with -fno-summary)
test transitive failure
+- run zflecs-tests failure
   +- zig test zflecs-tests Debug native success 4s MaxRSS:178M
      +- zig build-lib zflecs Debug native cached 25ms MaxRSS:16M
error: the following build command failed with exit code 1:
```

I've added a custom abort function that utilizes ```std.debug.dumpCurrentStackTrace``` and inserts a breakpoint.
```
D:\Projects\zig-gamedev\libs\zflecs>zig build test
run zflecs-tests: error: D:\Projects\zig-gamedev\libs\zflecs\libs\flecs\flecs.c:8845:0: 0x7ff770c10019 in ecs_is_alive (zflecs.lib)
    ecs_check(entity != 0, ECS_INVALID_PARAMETER, NULL);

D:\Projects\zig-gamedev\libs\zflecs\libs\flecs\flecs.c:7949:0: 0x7ff770c05c3e in ecs_get_id (zflecs.lib)
    ecs_check(ecs_is_alive(world, entity), ECS_INVALID_PARAMETER, NULL);

D:\Projects\zig-gamedev\libs\zflecs\src\zflecs.zig:2128:15: 0x7ff770b5e62d in get__anon_5526 (zflecs-tests.exe.obj)
    if (get_id(world, entity, id(T))) |ptr| {
              ^
D:\Projects\zig-gamedev\libs\zflecs\src\tests.zig:289:16: 0x7ff770b5e5d5 in test.zflecs.do_something_wonky (zflecs-tests.exe.obj)
    _ = ecs.get(world, ecs.id(Component), Component).?;
               ^
D:\Tools\zig-binaries\zig-windows-x86_64-0.11.0-dev.3218+b873ce1e0\lib\test_runner.zig:101:29: 0x7ff770b56835 in mainServer (zflecs-tests.exe.obj)
                test_fn.func() catch |err| switch (err) {
                            ^
D:\Tools\zig-binaries\zig-windows-x86_64-0.11.0-dev.3218+b873ce1e0\lib\test_runner.zig:35:26: 0x7ff770b5793e in main (zflecs-tests.exe.obj)
        return mainServer() catch @panic("internal test runner failure");
                         ^
D:\Tools\zig-binaries\zig-windows-x86_64-0.11.0-dev.3218+b873ce1e0\lib\std\start.zig:508:80: 0x7ff770b5843b in main (zflecs-tests.exe.obj)
    return @call(.always_inline, callMainWithArgs, .{ @intCast(usize, c_argc), @ptrCast([*][*:0]u8, c_argv), envp });
                                                                               ^
???:?:?: 0x7ff770bf4a24 in ??? (zflecs-tests.exe)
???:?:?: 0x7ff770bf4a7b in ??? (zflecs-tests.exe)
???:?:?: 0x7ff8de6926bc in ??? (KERNEL32.DLL)
???:?:?: 0x7ff8de9adfb7 in ??? (ntdll.dll)
fatal: flecs.c: 8845: assert: entity != 0 INVALID_PARAMETER
run zflecs-tests: error: while executing test 'test.zflecs.do_something_wonky', the following command exited with code 1 (expected exited with code 0):
```

Note that I have only tested this behavior on Windows. 
I've seen that flecs uses [backtrace](https://linux.die.net/man/3/backtrace) on Linux to print its stack trace. 
We might need to conditionally disable this if it conflicts with that.
