### PR TITLE
Fix #320: Replace std.builtin.Version in favor of std.SemanticVersion

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -355,7 +355,7 @@ fn ensureTarget(cross: std.zig.CrossTarget) !void {
 
             // If min. target macOS version is lesser than the min version we have available, then
             // our Dawn binary is incompatible with the target.
-            const min_available = std.builtin.Version{ .major = 12, .minor = 0 };
+            const min_available = std.SemanticVersion{ .major = 12, .minor = 0, .patch = 0 };
             if (target.os.version_range.semver.min.order(min_available) == .lt) break :blk false;
             break :blk true;
         },


### PR DESCRIPTION
Fix breaking zig change, see #320. 