### PR TITLE
Fully fix issue 318: std.math.max, std.math.min deprecated

### DIFF
--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -973,7 +973,7 @@ pub const GraphicsContext = struct {
             var current_src_mip_level: u32 = 0;
 
             while (true) {
-                const dispatch_num_mips = math.min(MipgenResources.max_levels_per_dispatch, total_num_mips);
+                const dispatch_num_mips = @min(MipgenResources.max_levels_per_dispatch, total_num_mips);
                 {
                     const pass = encoder.beginComputePass(null);
                     defer {
@@ -991,8 +991,8 @@ pub const GraphicsContext = struct {
                     pass.setBindGroup(0, gctx.lookupResource(bind_group).?, &.{mem.offset});
 
                     pass.dispatchWorkgroups(
-                        math.max(texture_info.size.width >> @intCast(u5, 3 + current_src_mip_level), 1),
-                        math.max(texture_info.size.height >> @intCast(u5, 3 + current_src_mip_level), 1),
+                        @max(texture_info.size.width >> @intCast(u5, 3 + current_src_mip_level), 1),
+                        @max(texture_info.size.height >> @intCast(u5, 3 + current_src_mip_level), 1),
                         1,
                     );
                 }

--- a/samples/audio_experiments/src/audio_experiments.zig
+++ b/samples/audio_experiments/src/audio_experiments.zig
@@ -366,8 +366,8 @@ fn update(demo: *DemoState) void {
         if (w32.GetAsyncKeyState(w32.VK_RBUTTON) < 0) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = zm.modAngle(demo.camera.yaw);
         }
     }

--- a/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
+++ b/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
@@ -134,7 +134,7 @@ const AudioState = struct {
         const frames = @ptrCast([*]f32, @alignCast(@sizeOf(f32), output));
 
         var i: u32 = 0;
-        while (i < math.min(num_frames, usable_samples_per_set)) : (i += 1) {
+        while (i < @min(num_frames, usable_samples_per_set)) : (i += 1) {
             audio.samples.items[base_index + i] = frames[i * num_channels];
         }
     }
@@ -765,8 +765,8 @@ fn update(demo: *DemoState) !void {
         if (window.getMouseButton(.right) == .press) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = zm.modAngle(demo.camera.yaw);
         }
     }
@@ -988,7 +988,7 @@ pub fn main() !void {
 
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
 
     zgui.init(allocator);

--- a/samples/bindless/src/bindless.zig
+++ b/samples/bindless/src/bindless.zig
@@ -952,8 +952,8 @@ fn update(demo: *DemoState) void {
         if (w32.GetAsyncKeyState(w32.VK_RBUTTON) < 0) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = vm.modAngle(demo.camera.yaw);
         }
     }

--- a/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
+++ b/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
@@ -391,8 +391,8 @@ fn update(demo: *DemoState) void {
         if (window.getMouseButton(.right) == .press) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = zm.modAngle(demo.camera.yaw);
         }
     }
@@ -1355,7 +1355,7 @@ pub fn main() !void {
 
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
 
     zgui.init(allocator);

--- a/samples/directml_convolution_test/src/directml_convolution_test.zig
+++ b/samples/directml_convolution_test/src/directml_convolution_test.zig
@@ -226,7 +226,7 @@ fn init(allocator: std.mem.Allocator) !DemoState {
     const conv_info = conv_cop.GetBindingProperties();
     const init_info = init_op.GetBindingProperties();
 
-    const temp_resource_size: u64 = math.max(init_info.TemporaryResourceSize, conv_info.TemporaryResourceSize);
+    const temp_resource_size: u64 = @max(init_info.TemporaryResourceSize, conv_info.TemporaryResourceSize);
     const persistent_resource_size: u64 = conv_info.PersistentResourceSize;
 
     const temp_buffer = if (temp_resource_size > 0) gctx.createCommittedResource(

--- a/samples/gamepad_wgpu/src/gamepad_wgpu.zig
+++ b/samples/gamepad_wgpu/src/gamepad_wgpu.zig
@@ -24,7 +24,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     zgui.init(allocator);
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
     _ = zgui.io.addFontFromFile(content_dir ++ "Roboto-Medium.ttf", math.floor(20.0 * scale_factor));
 

--- a/samples/gui_test_wgpu/src/gui_test_wgpu.zig
+++ b/samples/gui_test_wgpu/src/gui_test_wgpu.zig
@@ -65,7 +65,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     zgui.plot.init();
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
     const font_size = 16.0 * scale_factor;
     const font_large = zgui.io.addFontFromMemory(embedded_font_data, math.floor(font_size * 1.1));

--- a/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
+++ b/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
@@ -129,7 +129,7 @@ const DemoState = struct {
         zgui.init(allocator);
         const scale_factor = scale_factor: {
             const scale = window.getContentScale();
-            break :scale_factor math.max(scale[0], scale[1]);
+            break :scale_factor @max(scale[0], scale[1]);
         };
         const font_normal = zgui.io.addFontFromFile(
             content_dir ++ "Roboto-Medium.ttf",

--- a/samples/layers_wgpu/src/graphics.zig
+++ b/samples/layers_wgpu/src/graphics.zig
@@ -53,7 +53,7 @@ pub const State = struct {
         zgui.init(allocator);
         const scale_factor = scale_factor: {
             const scale = window.getContentScale();
-            break :scale_factor math.max(scale[0], scale[1]);
+            break :scale_factor @max(scale[0], scale[1]);
         };
         _ = zgui.io.addFontFromFile(content_dir ++ "Roboto-Medium.ttf", math.floor(16.0 * scale_factor));
 

--- a/samples/mesh_shader_test/src/mesh_shader_test.zig
+++ b/samples/mesh_shader_test/src/mesh_shader_test.zig
@@ -668,8 +668,8 @@ fn update(demo: *DemoState) void {
         if (w32.GetAsyncKeyState(w32.VK_RBUTTON) < 0) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = vm.modAngle(demo.camera.yaw);
         }
     }

--- a/samples/physically_based_rendering_wgpu/src/physically_based_rendering_wgpu.zig
+++ b/samples/physically_based_rendering_wgpu/src/physically_based_rendering_wgpu.zig
@@ -259,7 +259,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
                 image.bytes_per_component,
                 image.is_hdr,
             ),
-            .mip_level_count = math.log2_int(u32, math.max(image.width, image.height)) + 1,
+            .mip_level_count = math.log2_int(u32, @max(image.width, image.height)) + 1,
         });
         mesh_texv[tex_index] = gctx.createTextureView(mesh_tex[tex_index], .{});
 
@@ -566,8 +566,8 @@ fn update(demo: *DemoState) void {
         } else if (window.getMouseButton(.right) == .press) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = zm.modAngle(demo.camera.yaw);
         }
     }
@@ -1120,7 +1120,7 @@ pub fn main() !void {
 
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
 
     zgui.init(allocator);

--- a/samples/physics_test_wgpu/src/physics_test_wgpu.zig
+++ b/samples/physics_test_wgpu/src/physics_test_wgpu.zig
@@ -270,7 +270,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
             .binding = 0,
             .buffer_handle = gctx.uniforms.buffer,
             .offset = 0,
-            .size = math.max(@sizeOf(FrameUniforms), @sizeOf(DrawUniforms)),
+            .size = @max(@sizeOf(FrameUniforms), @sizeOf(DrawUniforms)),
         },
     });
 
@@ -444,8 +444,8 @@ fn update(demo: *DemoState) void {
         if (window.getMouseButton(.right) == .press) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = zm.modAngle(demo.camera.yaw);
         }
     }
@@ -664,7 +664,7 @@ pub fn main() !void {
 
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
 
     zgui.init(allocator);

--- a/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
+++ b/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
@@ -373,7 +373,7 @@ fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
         .binding = 0,
         .buffer_handle = gctx.uniforms.buffer,
         .offset = 0,
-        .size = math.max(@sizeOf(FrameUniforms), @sizeOf(DrawUniforms)),
+        .size = @max(@sizeOf(FrameUniforms), @sizeOf(DrawUniforms)),
     }});
 
     var drawables = std.ArrayList(Drawable).init(allocator);
@@ -464,8 +464,8 @@ fn update(demo: *DemoState) void {
         if (window.getMouseButton(.right) == .press) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = zm.modAngle(demo.camera.yaw);
         }
     }
@@ -687,7 +687,7 @@ pub fn main() !void {
 
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
 
     zgui.init(allocator);

--- a/samples/rasterization/src/rasterization.zig
+++ b/samples/rasterization/src/rasterization.zig
@@ -521,8 +521,8 @@ fn update(demo: *DemoState) void {
             if (w32.GetAsyncKeyState(w32.VK_RBUTTON) < 0) {
                 demo.camera.pitch += 0.0025 * delta_y;
                 demo.camera.yaw += 0.0025 * delta_x;
-                demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-                demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+                demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+                demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
                 demo.camera.yaw = zm.modAngle(demo.camera.yaw);
             }
         }

--- a/samples/simple_raytracer/src/simple_raytracer.zig
+++ b/samples/simple_raytracer/src/simple_raytracer.zig
@@ -1090,8 +1090,8 @@ fn update(demo: *DemoState) void {
         if (w32.GetAsyncKeyState(w32.VK_RBUTTON) < 0) {
             demo.camera.pitch += 0.0025 * delta_y;
             demo.camera.yaw += 0.0025 * delta_x;
-            demo.camera.pitch = math.min(demo.camera.pitch, 0.48 * math.pi);
-            demo.camera.pitch = math.max(demo.camera.pitch, -0.48 * math.pi);
+            demo.camera.pitch = @min(demo.camera.pitch, 0.48 * math.pi);
+            demo.camera.pitch = @max(demo.camera.pitch, -0.48 * math.pi);
             demo.camera.yaw = vm.modAngle(demo.camera.yaw);
         }
     }

--- a/samples/textured_quad_wgpu/src/textured_quad_wgpu.zig
+++ b/samples/textured_quad_wgpu/src/textured_quad_wgpu.zig
@@ -125,7 +125,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
             image.bytes_per_component,
             image.is_hdr,
         ),
-        .mip_level_count = math.log2_int(u32, math.max(image.width, image.height)) + 1,
+        .mip_level_count = math.log2_int(u32, @max(image.width, image.height)) + 1,
     });
     const texture_view = gctx.createTextureView(texture, .{});
 
@@ -364,7 +364,7 @@ pub fn main() !void {
 
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
 
     zgui.init(allocator);

--- a/samples/triangle_wgpu/src/triangle_wgpu.zig
+++ b/samples/triangle_wgpu/src/triangle_wgpu.zig
@@ -339,7 +339,7 @@ pub fn main() !void {
 
     const scale_factor = scale_factor: {
         const scale = window.getContentScale();
-        break :scale_factor math.max(scale[0], scale[1]);
+        break :scale_factor @max(scale[0], scale[1]);
     };
 
     zgui.init(allocator);


### PR DESCRIPTION
I tried to compile zig-gamedev with the latest Zig version (`0.11.0-dev.3677+e95fc2023`) and got a lot of deprecation messages about `std.math.min` and `std.math.max`, which are now `@min` and `@max`. I saw this was a reported issue (#318) that got resolved by PR #319, but it looks like some were missed. This PR should hopefully resolve all of the deprecation messages.