### PR TITLE
zpool: Fix int overflows

### DIFF
--- a/libs/zpool/src/pool.zig
+++ b/libs/zpool/src/pool.zig
@@ -33,7 +33,7 @@ pub const HandleError = error{
 ///
 /// const GPA = std.heap.GeneralPurposeAllocator;
 /// var gpa = GPA(.{}){};
-/// var pool = try TestPool.initMaxCapacity(gpa.allocator());
+/// var pool = try TexturePool.initMaxCapacity(gpa.allocator());
 /// defer pool.deinit();
 ///
 /// // creating a texture and adding it to the pool returns a handle
@@ -44,6 +44,11 @@ pub const HandleError = error{
 /// // elsewhere, use the handle to get `obj` or `desc` as needed
 /// const obj = pool.getColumn(handle, .obj);
 /// const desc = pool.getColumn(handle, .desc);
+///
+/// // ...
+///
+/// // once the texture is no longer needed, release it.
+/// _ = pool.removeIfLive(handle);
 /// ```
 pub fn Pool(
     comptime index_bits: u8,

--- a/libs/zpool/src/pool.zig
+++ b/libs/zpool/src/pool.zig
@@ -251,12 +251,12 @@ pub fn Pool(
         /// defined.
         pub fn clear(self: *Self) void {
             var ahandle = AddressableHandle{ .index = 0 };
-            for (self._curr_cycle) |cycle| {
+            for (self._curr_cycle, 0..) |cycle, i| {
                 if (isLiveCycle(cycle)) {
+                    ahandle.index = @intCast(AddressableIndex, i);
                     ahandle.cycle = cycle;
                     self.releaseAddressableHandleUnchecked(ahandle);
                 }
-                ahandle.index += 1;
             }
         }
 

--- a/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
+++ b/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
@@ -828,7 +828,7 @@ fn draw(demo: *DemoState) void {
         .mapped_at_creation = true,
     });
     const vertex_buffer = gctx.lookupResource(vertex_buffer_handle).?;
-    defer vertex_buffer.destroy();
+    defer gctx.destroyResource(vertex_buffer_handle);
     {
         const mem = vertex_buffer.getMappedRange(
             Vertex,


### PR DESCRIPTION
I found that `audio_experiments_wgpu` sample would crash after a few mins with an integer overflow:

- The iterators inside pool could overflow their loop counters when pool is full.
- The sample app itself was filling a pool due to not properly releasing handles.