### PR TITLE
add `plotText` to zgui.plot

### DIFF
--- a/libs/zgui/src/plot.zig
+++ b/libs/zgui/src/plot.zig
@@ -564,6 +564,29 @@ pub fn dragPoint(id: i32, args: DragPoint) bool {
 extern fn zguiPlot_DragPoint(id: i32, x: *f64, y: *f64, *const [4]f32, size: f32, flags: DragToolFlags) bool;
 
 //----------------------------------------------------------------------------------------------
+// PlotText
+const PlotTextFlags = packed struct(u32) {
+    vertical: bool = false,
+    _padding: u31 = 0,
+};
+const PlotText = struct {
+    x: f64,
+    y: f64,
+    pix_offset: [2]f32 = .{ 0, 0 },
+    flags: PlotTextFlags = .{},
+};
+pub fn plotText(text: [*:0]const u8, args:PlotText) void {
+    zguiPlot_PlotText(text, args.x, args.y, &args.pix_offset, args.flags);
+}
+extern fn zguiPlot_PlotText(
+    text:[*:0]const u8,
+    x:f64, y:f64,
+    pix_offset: *const [2]f32,
+    flags: PlotTextFlags,
+) void;
+
+
+//----------------------------------------------------------------------------------------------
 /// `pub fn showDemoWindow(popen: ?*bool) void`
 pub const showDemoWindow = zguiPlot_ShowDemoWindow;
 extern fn zguiPlot_ShowDemoWindow(popen: ?*bool) void;

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -2371,5 +2371,16 @@ ZGUI_API bool zguiPlot_DragPoint(
         flags
     );
 }
+
+ZGUI_API void zguiPlot_PlotText(
+        const char* text, 
+        double x, double y,
+        const float pix_offset[2],
+        ImPlotTextFlags flags=0
+) {
+    const ImVec2 p(pix_offset[0], pix_offset[1]);
+    ImPlot::PlotText(text, x, y, p, flags);
+}
+
 //--------------------------------------------------------------------------------------------------
 } /* extern "C" */


### PR DESCRIPTION
Adds the `plotText` call, useful for putting text onto charts next to points.  One thing I haven't figured it out is how to link the plots to a plot so that toggling the plot in the legend also toggles the text...