### PR TITLE
zphysics: Added Decorated Shapes

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -23,6 +23,9 @@
 #include <Jolt/Physics/Collision/Shape/ConvexHullShape.h>
 #include <Jolt/Physics/Collision/Shape/HeightFieldShape.h>
 #include <Jolt/Physics/Collision/Shape/MeshShape.h>
+#include <Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h>
+#include <Jolt/Physics/Collision/Shape/ScaledShape.h>
+#include <Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h>
 #include <Jolt/Physics/Collision/PhysicsMaterial.h>
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyActivationListener.h>
@@ -181,6 +184,23 @@ FN(toJph)(const JPC_ConvexShapeSettings *in) {
 FN(toJph)(JPC_ConvexShapeSettings *in) {
     ENSURE_TYPE(in, JPH::ConvexShapeSettings);
     return reinterpret_cast<JPH::ConvexShapeSettings *>(in);
+}
+
+FN(toJpc)(JPH::RotatedTranslatedShapeSettings *in) {
+    assert(in);
+    return reinterpret_cast<JPC_DecoratedShapeSettings *>(in);
+}
+FN(toJpc)(JPH::ScaledShapeSettings *in) {
+    assert(in);
+    return reinterpret_cast<JPC_DecoratedShapeSettings *>(in);
+}
+FN(toJpc)(JPH::OffsetCenterOfMassShapeSettings *in) {
+    assert(in);
+    return reinterpret_cast<JPC_DecoratedShapeSettings *>(in);
+}
+FN(toJph)(JPC_DecoratedShapeSettings *in) {
+    ENSURE_TYPE(in, JPH::DecoratedShapeSettings);
+    return reinterpret_cast<JPH::DecoratedShapeSettings *>(in);
 }
 
 FN(toJph)(const JPC_CollisionGroup *in) { assert(in); return reinterpret_cast<const JPH::CollisionGroup *>(in); }
@@ -1548,6 +1568,41 @@ JPC_API void
 JPC_MeshShapeSettings_Sanitize(JPC_MeshShapeSettings *in_settings)
 {
     toJph(in_settings)->Sanitize();
+}
+//--------------------------------------------------------------------------------------------------
+//
+// JPC_DecoratedShapeSettings (-> JPC_ShapeSettings)
+//
+//--------------------------------------------------------------------------------------------------
+JPC_API JPC_DecoratedShapeSettings *
+JPC_RotatedTranslatedShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
+                                          const JPC_Real in_rotated[4],
+                                          const JPC_Real in_translated[3])
+{
+    auto settings = new JPH::RotatedTranslatedShapeSettings(loadRVec3(in_translated),
+                                                            JPH::Quat(loadVec4(in_rotated)),
+                                                            toJph(in_inner_shape_settings));
+    settings->AddRef();
+    return toJpc(settings);
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API JPC_DecoratedShapeSettings *
+JPC_ScaledShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
+                               const JPC_Real in_scale[3])
+{
+    auto settings = new JPH::ScaledShapeSettings(toJph(in_inner_shape_settings), loadRVec3(in_scale));
+    settings->AddRef();
+    return toJpc(settings);
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API JPC_DecoratedShapeSettings *
+JPC_OffsetCenterOfMassShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
+                                           const JPC_Real in_center_of_mass[3])
+{
+    auto settings = new JPH::OffsetCenterOfMassShapeSettings(loadRVec3(in_center_of_mass),
+                                                             toJph(in_inner_shape_settings));
+    settings->AddRef();
+    return toJpc(settings);
 }
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -247,6 +247,7 @@ typedef struct JPC_CylinderShapeSettings       JPC_CylinderShapeSettings;
 typedef struct JPC_ConvexHullShapeSettings     JPC_ConvexHullShapeSettings;
 typedef struct JPC_HeightFieldShapeSettings    JPC_HeightFieldShapeSettings;
 typedef struct JPC_MeshShapeSettings           JPC_MeshShapeSettings;
+typedef struct JPC_DecoratedShapeSettings      JPC_DecoratedShapeSettings;
 
 typedef struct JPC_PhysicsSystem JPC_PhysicsSystem;
 typedef struct JPC_SharedMutex   JPC_SharedMutex;
@@ -1312,6 +1313,23 @@ JPC_MeshShapeSettings_SetMaxTrianglesPerLeaf(JPC_MeshShapeSettings *in_settings,
 
 JPC_API void
 JPC_MeshShapeSettings_Sanitize(JPC_MeshShapeSettings *in_settings);
+//--------------------------------------------------------------------------------------------------
+//
+// JPC_DecoratedShapeSettings (-> JPC_ShapeSettings)
+//
+//--------------------------------------------------------------------------------------------------
+JPC_API JPC_DecoratedShapeSettings *
+JPC_RotatedTranslatedShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
+                                          const JPC_Real in_rotated[4],
+                                          const JPC_Real in_translated[3]);
+
+JPC_API JPC_DecoratedShapeSettings *
+JPC_ScaledShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
+                               const JPC_Real in_scale[3]);
+
+JPC_API JPC_DecoratedShapeSettings *
+JPC_OffsetCenterOfMassShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
+                                           const JPC_Real in_center_of_mass[3]);
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_BodyManager_DrawSettings

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -2553,6 +2553,46 @@ pub const MeshShapeSettings = opaque {
 };
 //--------------------------------------------------------------------------------------------------
 //
+// DecoratedShapeSettings (-> ShapeSettings)
+//
+//--------------------------------------------------------------------------------------------------
+pub const DecoratedShapeSettings = opaque {
+    pub usingnamespace ShapeSettings.Methods(@This());
+
+    pub fn createRotatedTranslated(
+        inner_shape: *const ShapeSettings,
+        rotation: [4]Real,
+        translation: [3]Real,
+    ) !*DecoratedShapeSettings {
+        const settings = c.JPC_RotatedTranslatedShapeSettings_Create(
+            @as(*const c.JPC_ShapeSettings, @ptrCast(inner_shape)),
+            &rotation,
+            &translation,
+        );
+        if (settings == null) return error.FailedToCreateDecoratedShapeSettings;
+        return @as(*DecoratedShapeSettings, @ptrCast(settings));
+    }
+
+    pub fn createScaled(inner_shape: *const ShapeSettings, scale: [3]Real) !*DecoratedShapeSettings {
+        const settings = c.JPC_ScaledShapeSettings_Create(
+            @as(*const c.JPC_ShapeSettings, @ptrCast(inner_shape)),
+            &scale,
+        );
+        if (settings == null) return error.FailedToCreateDecoratedShapeSettings;
+        return @as(*DecoratedShapeSettings, @ptrCast(settings));
+    }
+
+    pub fn createOffsetCenterOfMass(inner_shape: *const ShapeSettings, offset: [3]Real) !*DecoratedShapeSettings {
+        const settings = c.JPC_OffsetCenterOfMassShapeSettings_Create(
+            @as(*const c.JPC_ShapeSettings, @ptrCast(inner_shape)),
+            &offset,
+        );
+        if (settings == null) return error.FailedToCreateDecoratedShapeSettings;
+        return @as(*DecoratedShapeSettings, @ptrCast(settings));
+    }
+};
+//--------------------------------------------------------------------------------------------------
+//
 // Shape
 //
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Let me know if this isn't the way you'd put this part of the API together. I can redo this any way you'd like.

I just threw something in there quickly because I needed it, and I've tested it by using it in my own project.

I haven't written these into the actual tests yet though.

I combined each of Jolt's three existing inheritors of the DecoratedShape base class into the same type in the Zig API, because including the complexity of that two-deep inheritance seemed unnecessary. Again, let me know if you disagree.