### PR TITLE
zsdl: compile error if use ttf but not enabled

### DIFF
--- a/libs/zsdl/build.zig
+++ b/libs/zsdl/build.zig
@@ -1,10 +1,15 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
+pub const Options = struct {
+    enable_ttf: bool = false,
+};
+
 pub const Package = struct {
+    options: Options,
     zsdl: *std.Build.Module,
+    zsdl_options: *std.Build.Module,
     install: *std.Build.Step,
-    ttf: bool,
 
     pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
         exe.linkLibC();
@@ -24,7 +29,7 @@ pub const Package = struct {
                 exe.linkSystemLibraryName("SDL2");
                 exe.linkSystemLibraryName("SDL2main");
 
-                if (pkg.ttf) {
+                if (pkg.options.enable_ttf) {
                     exe.linkSystemLibraryName("SDL2_ttf");
                 }
             },
@@ -36,7 +41,7 @@ pub const Package = struct {
                 exe.linkSystemLibraryName("SDL2-2.0");
                 exe.addRPath("$ORIGIN");
 
-                if (pkg.ttf) {
+                if (pkg.options.enable_ttf) {
                     exe.linkSystemLibraryName("SDL2_ttf-2.0");
                 }
             },
@@ -45,7 +50,7 @@ pub const Package = struct {
                 exe.linkFramework("SDL2");
                 exe.addRPath("@executable_path/Frameworks");
 
-                if (pkg.ttf) {
+                if (pkg.options.enable_ttf) {
                     exe.linkFramework("SDL2_ttf");
                 }
             },
@@ -59,11 +64,22 @@ pub fn package(
     target: std.zig.CrossTarget,
     _: std.builtin.Mode,
     args: struct {
-        ttf: bool = false,
+        options: Options = .{},
     },
 ) Package {
+    const options_step = b.addOptions();
+    inline for (std.meta.fields(Options)) |option_field| {
+        const option_val = @field(args.options, option_field.name);
+        options_step.addOption(@TypeOf(option_val), option_field.name, option_val);
+    }
+
+    const options = options_step.createModule();
+
     const zsdl = b.createModule(.{
         .source_file = .{ .path = thisDir() ++ "/src/zsdl.zig" },
+        .dependencies = &.{
+            .{ .name = "zsdl_options", .module = options },
+        },
     });
 
     const install_step = b.allocator.create(std.Build.Step) catch @panic("OOM");
@@ -76,7 +92,7 @@ pub fn package(
                 "bin/SDL2.dll",
             ).step,
         );
-        if (args.ttf) {
+        if (args.options.enable_ttf) {
             install_step.dependOn(
                 &b.addInstallFile(
                     .{ .path = thisDir() ++ "/libs/x86_64-windows-gnu/bin/SDL2_ttf.dll" },
@@ -91,7 +107,7 @@ pub fn package(
                 "bin/libSDL2-2.0.so.0",
             ).step,
         );
-        if (args.ttf) {
+        if (args.options.enable_ttf) {
             install_step.dependOn(
                 &b.addInstallFile(
                     .{ .path = thisDir() ++ "/libs/x86_64-linux-gnu/lib/libSDL2_ttf-2.0.so" },
@@ -107,7 +123,7 @@ pub fn package(
                 .install_subdir = "bin/Frameworks/SDL2.framework",
             }).step,
         );
-        if (args.ttf) {
+        if (args.options.enable_ttf) {
             install_step.dependOn(
                 &b.addInstallDirectory(.{
                     .source_dir = .{ .path = thisDir() ++ "/libs/macos/Frameworks/SDL2_ttf.framework" },
@@ -119,9 +135,10 @@ pub fn package(
     } else unreachable;
 
     return .{
+        .options = args.options,
         .zsdl = zsdl,
+        .zsdl_options = options,
         .install = install_step,
-        .ttf = args.ttf,
     };
 }
 

--- a/libs/zsdl/src/zsdl.zig
+++ b/libs/zsdl/src/zsdl.zig
@@ -1,4 +1,5 @@
+const options = @import("zsdl_options");
+
 pub usingnamespace @import("sdl2.zig");
 
-pub const ttf = @import("ttf.zig");
-
+pub const ttf = if (options.enable_ttf) @import("ttf.zig") else @compileError("zsdl: SDL_ttf not enabled; check your build options.");


### PR DESCRIPTION
I know this doesn't look very valuable. This is part of a series of small changes to move us a little closer to a future SDL3 migration. The general intention is to minimize potential for conflicts and to make sdl2/sdl3 diffs more pleasant to read as they are developed in parallel.