### PR TITLE
Add option to zgui to use imgui out of source

### DIFF
--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -9,6 +9,10 @@ pub const Backend = enum {
 pub const Options = struct {
     backend: Backend,
     shared: bool = false,
+    /// use bundled imgui source
+    with_imgui: bool = true,
+    /// use bundled implot source
+    with_implot: bool = true,
 };
 
 pub const Package = struct {
@@ -75,15 +79,19 @@ pub fn package(
 
     zgui_c_cpp.addCSourceFile(thisDir() ++ "/src/zgui.cpp", cflags);
 
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui.cpp", cflags);
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_widgets.cpp", cflags);
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_tables.cpp", cflags);
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_draw.cpp", cflags);
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_demo.cpp", cflags);
+    if (args.options.with_imgui) {
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui.cpp", cflags);
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_widgets.cpp", cflags);
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_tables.cpp", cflags);
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_draw.cpp", cflags);
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/imgui_demo.cpp", cflags);
+    }
 
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/implot_demo.cpp", cflags);
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/implot.cpp", cflags);
-    zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/implot_items.cpp", cflags);
+    if (args.options.with_implot) {
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/implot_demo.cpp", cflags);
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/implot.cpp", cflags);
+        zgui_c_cpp.addCSourceFile(thisDir() ++ "/libs/imgui/implot_items.cpp", cflags);
+    }
 
     switch (args.options.backend) {
         .glfw_wgpu => {

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -1469,8 +1469,7 @@ pub fn comboFromEnum(
     /// that is backed by some kind of integer that can safely cast into an
     /// i32 (the underlying imgui restriction)
     current_item: anytype,
-) bool 
-{
+) bool {
     const item_names = comptime lbl: {
         const item_type = @typeInfo(@TypeOf(current_item.*));
         switch (item_type) {
@@ -1483,23 +1482,17 @@ pub fn comboFromEnum(
                 break :lbl str;
             },
             else => {
-                @compileError(
-                    "Error: current_item must be a pointer-to-an-enum, not a "
-                    ++ @TypeOf(current_item)
-                );
-            }
+                @compileError("Error: current_item must be a pointer-to-an-enum, not a " ++ @TypeOf(current_item));
+            },
         }
     };
 
-    var item:i32 = @intCast(@intFromEnum(current_item.*));
+    var item: i32 = @intCast(@intFromEnum(current_item.*));
 
-    const result = combo(
-        label,
-        .{
-            .items_separated_by_zeros = item_names,
-            .current_item = &item,
-        }
-    );
+    const result = combo(label, .{
+        .items_separated_by_zeros = item_names,
+        .current_item = &item,
+    });
 
     current_item.* = @enumFromInt(item);
 
@@ -2914,8 +2907,8 @@ pub const BeginTable = struct {
     outer_size: [2]f32 = .{ 0, 0 },
     inner_width: f32 = 0,
 };
-pub fn beginTable(name: [:0]const u8, args: BeginTable) void {
-    zguiBeginTable(name, args.column, args.flags, &args.outer_size, args.inner_width);
+pub fn beginTable(name: [:0]const u8, args: BeginTable) bool {
+    return zguiBeginTable(name, args.column, args.flags, &args.outer_size, args.inner_width);
 }
 extern fn zguiBeginTable(
     str_id: [*:0]const u8,
@@ -2923,7 +2916,7 @@ extern fn zguiBeginTable(
     flags: TableFlags,
     outer_size: *const [2]f32,
     inner_width: f32,
-) void;
+) bool;
 
 pub fn endTable() void {
     zguiEndTable();

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1497,14 +1497,14 @@ ZGUI_API void zguiCloseCurrentPopup(void) {
 // Tables
 //
 //--------------------------------------------------------------------------------------------------
-ZGUI_API void zguiBeginTable(
+ZGUI_API bool zguiBeginTable(
     const char* str_id,
     int column,
     ImGuiTableFlags flags,
     const float outer_size[2],
     float inner_width
 ) {
-    ImGui::BeginTable(str_id, column, flags, { outer_size[0], outer_size[1] }, inner_width);
+    return ImGui::BeginTable(str_id, column, flags, { outer_size[0], outer_size[1] }, inner_width);
 }
 
 ZGUI_API void zguiEndTable(void) {


### PR DESCRIPTION
For example, if I want to use other backends, it's better to link in imgui myself