### PR TITLE
zgpu: Expose present mode on context creation

### DIFF
--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -51,7 +51,7 @@ pub const GraphicsContext = struct {
         } = .{},
     } = .{},
 
-    pub fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*GraphicsContext {
+    pub fn create(allocator: std.mem.Allocator, window: *zglfw.Window, present_mode: wgpu.PresentMode) !*GraphicsContext {
         const checkGraphicsApiSupport = (struct {
             fn impl() error{VulkanNotSupported}!void {
                 // TODO: On Windows we should check if DirectX 12 is supported (Windows 10+).
@@ -197,7 +197,7 @@ pub const GraphicsContext = struct {
             .format = swapchain_format,
             .width = @intCast(framebuffer_size[0]),
             .height = @intCast(framebuffer_size[1]),
-            .present_mode = .fifo,
+            .present_mode = present_mode,
         };
         const swapchain = device.createSwapChain(surface, swapchain_descriptor);
         errdefer swapchain.release();

--- a/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
+++ b/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
@@ -223,7 +223,7 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();

--- a/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
+++ b/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
@@ -117,7 +117,7 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();

--- a/samples/gamepad_wgpu/src/gamepad_wgpu.zig
+++ b/samples/gamepad_wgpu/src/gamepad_wgpu.zig
@@ -14,7 +14,7 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     const success = zglfw.Gamepad.updateMappings(@embedFile("gamecontrollerdb.txt"));
     if (!success) {

--- a/samples/gui_test_wgpu/src/gui_test_wgpu.zig
+++ b/samples/gui_test_wgpu/src/gui_test_wgpu.zig
@@ -21,7 +21,7 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();

--- a/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
+++ b/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
@@ -124,7 +124,7 @@ const DemoState = struct {
     depth_texture_view: zgpu.TextureViewHandle,
 
     fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
-        const gctx = try zgpu.GraphicsContext.create(allocator, window);
+        const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
         zgui.init(allocator);
         const scale_factor = scale_factor: {

--- a/samples/layers_wgpu/src/graphics.zig
+++ b/samples/layers_wgpu/src/graphics.zig
@@ -48,7 +48,7 @@ pub const State = struct {
     depth_texture_view: zgpu.TextureViewHandle,
 
     pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !State {
-        const gctx = try zgpu.GraphicsContext.create(allocator, window);
+        const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
         zgui.init(allocator);
         const scale_factor = scale_factor: {

--- a/samples/monolith/src/monolith.zig
+++ b/samples/monolith/src/monolith.zig
@@ -665,7 +665,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     // Graphics
     //
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     // Uniform buffer and layout
     const uniform_bgl = gctx.createBindGroupLayout(&.{

--- a/samples/physically_based_rendering_wgpu/src/physically_based_rendering_wgpu.zig
+++ b/samples/physically_based_rendering_wgpu/src/physically_based_rendering_wgpu.zig
@@ -164,7 +164,7 @@ fn loadAllMeshes(
 }
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();

--- a/samples/physics_test_wgpu/src/physics_test_wgpu.zig
+++ b/samples/physics_test_wgpu/src/physics_test_wgpu.zig
@@ -257,7 +257,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     // Graphics
     //
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     // Uniform buffer and layout
     const uniform_bgl = gctx.createBindGroupLayout(&.{

--- a/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
+++ b/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
@@ -303,7 +303,7 @@ fn initScene(
 }
 
 fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();

--- a/samples/textured_quad_wgpu/src/textured_quad_wgpu.zig
+++ b/samples/textured_quad_wgpu/src/textured_quad_wgpu.zig
@@ -72,7 +72,7 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();

--- a/samples/triangle_wgpu/src/triangle_wgpu.zig
+++ b/samples/triangle_wgpu/src/triangle_wgpu.zig
@@ -54,7 +54,7 @@ const DemoState = struct {
 };
 
 fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window);
+    const gctx = try zgpu.GraphicsContext.create(allocator, window, .fifo);
 
     // Create a bind group layout needed for our render pipeline.
     const bind_group_layout = gctx.createBindGroupLayout(&.{


### PR DESCRIPTION
Having vsync off can be desirable sometimes, but it's currently forced on