### PR TITLE
Add sample minimal_zgpu_zgui

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -160,6 +160,7 @@ fn samplesCrossPlatform(b: *std.Build, options: Options) void {
     const bullet_physics_test_wgpu = @import("samples/bullet_physics_test_wgpu/build.zig");
     const audio_experiments_wgpu = @import("samples/audio_experiments_wgpu/build.zig");
     const gui_test_wgpu = @import("samples/gui_test_wgpu/build.zig");
+    const minimal_zgpu_zgui = @import("samples/minimal_zgpu_zgui/build.zig");
     const instanced_pills_wgpu = @import("samples/instanced_pills_wgpu/build.zig");
     const layers_wgpu = @import("samples/layers_wgpu/build.zig");
     const gamepad_wgpu = @import("samples/gamepad_wgpu/build.zig");
@@ -170,6 +171,7 @@ fn samplesCrossPlatform(b: *std.Build, options: Options) void {
     install(b, triangle_wgpu.build(b, options), "triangle_wgpu");
     install(b, textured_quad_wgpu.build(b, options), "textured_quad_wgpu");
     install(b, gui_test_wgpu.build(b, options), "gui_test_wgpu");
+    install(b, minimal_zgpu_zgui.build(b, options), "minimal_zgpu_zgui");
     install(b, physically_based_rendering_wgpu.build(b, options), "physically_based_rendering_wgpu");
     install(b, instanced_pills_wgpu.build(b, options), "instanced_pills_wgpu");
     install(b, gamepad_wgpu.build(b, options), "gamepad_wgpu");

--- a/libs/zgui/README.md
+++ b/libs/zgui/README.md
@@ -1,6 +1,6 @@
 # zgui v1.89.6 - dear imgui bindings
 
-Easy to use, hand-crafted API with default arguments, named parameters and Zig style text formatting. For a test application please see [here](https://github.com/michal-z/zig-gamedev/tree/main/samples/gui_test_wgpu).
+Easy to use, hand-crafted API with default arguments, named parameters and Zig style text formatting. [Here](https://github.com/michal-z/zig-gamedev/tree/main/samples/minimal_zgpu_zgui) is a simple sample application, and [here](https://github.com/michal-z/zig-gamedev/tree/main/samples/gui_test_wgpu) is a full one.
 
 ## Features
 
@@ -13,7 +13,7 @@ Easy to use, hand-crafted API with default arguments, named parameters and Zig s
 
 Copy `zgui` folder to a `libs` subdirectory of the root of your project.
 
-To get glfw/wgpu rendering backend working also copy `zgpu`, `zglfw` and `zpool` folders (see [zgpu](https://github.com/michal-z/zig-gamedev/tree/main/libs/zgpu) for the details). Alternatively, you can provide your own rendering backend, see: [backend_glfw_wgpu.zig](src/backend_glfw_wgpu.zig) for an example.
+To get glfw/wgpu rendering backend working also copy `zgpu`, `zglfw`, `zpool` and `system-sdk` folders (see [zgpu](https://github.com/michal-z/zig-gamedev/tree/main/libs/zgpu) for the details). Alternatively, you can provide your own rendering backend, see: [backend_glfw_wgpu.zig](src/backend_glfw_wgpu.zig) for an example.
 
 Then in your `build.zig` add:
 ```zig

--- a/samples/minimal_zgpu_zgui/README.md
+++ b/samples/minimal_zgpu_zgui/README.md
@@ -1,0 +1,5 @@
+## minimal zgpu zgui
+
+This minimal sample has a button that prints a message to the console when pressed.
+
+![image](screenshot.png)

--- a/samples/minimal_zgpu_zgui/build.zig
+++ b/samples/minimal_zgpu_zgui/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+const Options = @import("../../build.zig").Options;
+
+const demo_name = "minimal_zgpu_zgui";
+const content_dir = demo_name ++ "_content/";
+
+pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+    const exe = b.addExecutable(.{
+        .name = demo_name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .target = options.target,
+        .optimize = options.optimize,
+    });
+
+    const zgui_pkg = @import("../../build.zig").zgui_pkg;
+    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
+
+    zgui_pkg.link(exe);
+    zgpu_pkg.link(exe);
+    zglfw_pkg.link(exe);
+
+    const exe_options = b.addOptions();
+    exe.addOptions("build_options", exe_options);
+    exe_options.addOption([]const u8, "content_dir", content_dir);
+    // exe_options.addOption([]const u8, "content_dir", thisDir() ++ "/" ++ content_dir);
+
+    const install_content_step = b.addInstallDirectory(.{
+        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .install_dir = .{ .custom = "" },
+        .install_subdir = "bin/" ++ content_dir,
+    });
+    exe.step.dependOn(&install_content_step.step);
+
+    return exe;
+}
+
+inline fn thisDir() []const u8 {
+    return comptime std.fs.path.dirname(@src().file) orelse ".";
+}

--- a/samples/minimal_zgpu_zgui/minimal_zgpu_zgui_content/Roboto-Medium.ttf
+++ b/samples/minimal_zgpu_zgui/minimal_zgpu_zgui_content/Roboto-Medium.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559132c89ad51d8a2ba5b171887a44a7ba93776e205f553573de228e64b45f8
+size 162588

--- a/samples/minimal_zgpu_zgui/screenshot.png
+++ b/samples/minimal_zgpu_zgui/screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e18a0cef72f2cb0366d4953f1d5e233ae892e2ba960f4f750bcf840cdeae69cc
+size 7444

--- a/samples/minimal_zgpu_zgui/src/minimal_zgpu_zgui.zig
+++ b/samples/minimal_zgpu_zgui/src/minimal_zgpu_zgui.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+
+const zglfw = @import("zglfw");
+const zgpu = @import("zgpu");
+const zgui = @import("zgui");
+
+const content_dir = @import("build_options").content_dir;
+const window_title = "zig-gamedev: minimal zgpu zgui";
+
+pub fn main() !void {
+    zglfw.init() catch {
+        std.log.err("Failed to initialize GLFW library.", .{});
+        return;
+    };
+    defer zglfw.terminate();
+
+    const window = zglfw.Window.create(800, 500, window_title, null) catch {
+        std.log.err("Failed to create window.", .{});
+        return;
+    };
+    defer window.destroy();
+    window.setSizeLimits(400, 400, -1, -1);
+
+    var gpa_state = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa_state.deinit();
+    const gpa = gpa_state.allocator();
+
+    const gctx = try zgpu.GraphicsContext.create(gpa, window, .{});
+    defer gctx.destroy(gpa);
+
+    zgui.init(gpa);
+    defer zgui.deinit();
+
+    _ = zgui.io.addFontFromFile(content_dir ++ "Roboto-Medium.ttf", 16.0);
+
+    zgui.backend.init(
+        window,
+        gctx.device,
+        @intFromEnum(zgpu.GraphicsContext.swapchain_format),
+    );
+    defer zgui.backend.deinit();
+
+    while (!window.shouldClose() and window.getKey(.escape) != .press) {
+        zglfw.pollEvents();
+
+        zgui.backend.newFrame(
+            gctx.swapchain_descriptor.width,
+            gctx.swapchain_descriptor.height,
+        );
+
+        // Set the starting window position and size to custom values
+        zgui.setNextWindowPos(.{ .x = 20.0, .y = 20.0, .cond = .first_use_ever });
+        zgui.setNextWindowSize(.{ .w = -1.0, .h = -1.0, .cond = .first_use_ever });
+
+        if (zgui.begin("My window", .{})) {
+            if (zgui.button("Press me!", .{ .w = 200.0 })) {
+                std.debug.print("Button pressed\n", .{});
+            }
+        }
+        zgui.end();
+
+        const swapchain_texv = gctx.swapchain.getCurrentTextureView();
+        defer swapchain_texv.release();
+
+        const commands = commands: {
+            const encoder = gctx.device.createCommandEncoder(null);
+            defer encoder.release();
+
+            // GUI pass
+            {
+                const pass = zgpu.beginRenderPassSimple(encoder, .load, swapchain_texv, null, null, null);
+                defer zgpu.endReleasePass(pass);
+                zgui.backend.draw(pass);
+            }
+
+            break :commands encoder.finish(null);
+        };
+        defer commands.release();
+
+        gctx.submit(&.{commands});
+        _ = gctx.present();
+    }
+}


### PR DESCRIPTION
I am deliberately letting the program crash at the moment, rather than using the commented out line in this sample's build.zig, since the commented out line wasn't necessary in the other samples. In other samples `exe_options.addOption([]const u8, "content_dir", content_dir);` "just works".

If someone could verify that the program also crashes for them, that'd be great. A tip on why the crash occurs/how to fix the crash would be even better, of course! :)

Any stylistic feedback that doesn't add more than one or two lines of code is also welcome.