### PR TITLE
build system exploration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@
 zig-cache
 zig-out
 backup
+
+# Ignore special system paths
+*.DS_Store

--- a/experiments/build.zig
+++ b/experiments/build.zig
@@ -1,8 +1,15 @@
 const std = @import("std");
-const Options = @import("../build.zig").Options;
 
-pub fn build(b: *std.Build, options: Options) void {
-    @import("genart/build.zig").build(b, options);
+pub const Options = struct {
+    optimize: std.builtin.Mode,
+    target: std.zig.CrossTarget,
+};
+
+pub fn buildWithOptions(
+    b: *std.Build,
+    options: Options,
+) void {
+    @import("genart/build.zig").buildWithOptions(b, options);
 }
 
 inline fn thisDir() []const u8 {

--- a/samples/audio_experiments/build.zig
+++ b/samples/audio_experiments/build.zig
@@ -1,21 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "audio_experiments_content/";
+
+pub const name = "audio_experiments";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "audio_experiments",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/audio_experiments.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zxaudio2_pkg = @import("../../build.zig").zxaudio2_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zxaudio2_pkg = @import("../build.zig").zxaudio2_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true, .xaudio2 = true });
     common_pkg.link(exe);

--- a/samples/audio_experiments_wgpu/build.zig
+++ b/samples/audio_experiments_wgpu/build.zig
@@ -1,23 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 
-const demo_name = "audio_experiments_wgpu";
-const content_dir = demo_name ++ "_content/";
+pub const name = "audio_experiments_wgpu";
+const content_dir = name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = demo_name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .name = name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zaudio_pkg = @import("../../build.zig").zaudio_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zaudio_pkg = @import("../build.zig").zaudio_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/audio_playback_test/build.zig
+++ b/samples/audio_playback_test/build.zig
@@ -1,19 +1,21 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "audio_playback_test_content/";
+
+pub const name = "audio_playback_test";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "audio_playback_test",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/audio_playback_test.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     common_pkg.link(exe);

--- a/samples/bindless/build.zig
+++ b/samples/bindless/build.zig
@@ -1,21 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "bindless_content/";
+
+pub const name = "bindless";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "bindless",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/bindless.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
-    const zstbi_pkg = @import("../../build.zig").zstbi_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
+    const zstbi_pkg = @import("../build.zig").zstbi_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     zmesh_pkg.link(exe);

--- a/samples/build.zig
+++ b/samples/build.zig
@@ -1,0 +1,212 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub const Options = struct {
+    optimize: std.builtin.Mode,
+    target: std.zig.CrossTarget,
+
+    zd3d12_enable_debug_layer: bool,
+    zd3d12_enable_gbv: bool,
+
+    zpix_enable: bool,
+};
+
+pub fn buildWithOptions(b: *std.Build, options: Options) void {
+    packagesCrossPlatform(b, options);
+
+    inline for (samples_cross_platform) |sample| {
+        install(b, sample, options);
+    }
+
+    if (options.target.isWindows() and
+        (builtin.target.os.tag == .windows or builtin.target.os.tag == .linux))
+    {
+        packagesWindowsLinux(b, options);
+
+        inline for (samples_windows_linux) |sample| {
+            install(b, sample, options);
+        }
+
+        if (builtin.target.os.tag == .windows) {
+            packagesWindows(b, options);
+
+            inline for (samples_windows) |sample| {
+                install(b, sample, options);
+            }
+        }
+    }
+}
+
+const samples_cross_platform = .{
+    @import("minimal_glfw_gl/build.zig"),
+    @import("minimal_sdl_gl/build.zig"),
+    @import("triangle_wgpu/build.zig"),
+    @import("procedural_mesh_wgpu/build.zig"),
+    @import("textured_quad_wgpu/build.zig"),
+    @import("physically_based_rendering_wgpu/build.zig"),
+    @import("bullet_physics_test_wgpu/build.zig"),
+    @import("audio_experiments_wgpu/build.zig"),
+    @import("gui_test_wgpu/build.zig"),
+    @import("minimal_zgpu_zgui/build.zig"),
+    @import("instanced_pills_wgpu/build.zig"),
+    @import("layers_wgpu/build.zig"),
+    @import("gamepad_wgpu/build.zig"),
+    @import("physics_test_wgpu/build.zig"),
+    @import("monolith/build.zig"),
+};
+
+const samples_windows_linux = .{
+    @import("minimal_d3d12/build.zig"),
+    @import("textured_quad/build.zig"),
+    @import("triangle/build.zig"),
+    @import("mesh_shader_test/build.zig"),
+    @import("rasterization/build.zig"),
+    @import("bindless/build.zig"),
+    @import("simple_raytracer/build.zig"),
+};
+
+const samples_windows = .{
+    //@import("audio_playback_test/build.zig"),
+    //@import("audio_experiments/build.zig"),
+    @import("vector_graphics_test/build.zig"),
+    //@import("directml_convolution_test/build.zig"),
+};
+
+fn install(b: *std.Build, sample: anytype, options: Options) void {
+    const exe = sample.build(b, options);
+
+    // TODO: Problems with LTO on Windows.
+    exe.want_lto = false;
+    if (exe.optimize == .ReleaseFast)
+        exe.strip = true;
+
+    const install_step = b.step(sample.name, "Build '" ++ sample.name ++ "' demo");
+    install_step.dependOn(&b.addInstallArtifact(exe, .{}).step);
+
+    const run_step = b.step(sample.name ++ "-run", "Run '" ++ sample.name ++ "' demo");
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(install_step);
+    run_step.dependOn(&run_cmd.step);
+
+    b.getInstallStep().dependOn(install_step);
+}
+
+const zsdl = @import("../libs/zsdl/build.zig");
+const zopengl = @import("../libs/zopengl/build.zig");
+const zmath = @import("../libs/zmath/build.zig");
+const zglfw = @import("../libs/zglfw/build.zig");
+const zpool = @import("../libs/zpool/build.zig");
+const zjobs = @import("../libs/zjobs/build.zig");
+const zmesh = @import("../libs/zmesh/build.zig");
+const znoise = @import("../libs/znoise/build.zig");
+const zstbi = @import("../libs/zstbi/build.zig");
+const zwin32 = @import("../libs/zwin32/build.zig");
+const zd3d12 = @import("../libs/zd3d12/build.zig");
+const zxaudio2 = @import("../libs/zxaudio2/build.zig");
+const zpix = @import("../libs/zpix/build.zig");
+const common = @import("../libs/common/build.zig");
+const zbullet = @import("../libs/zbullet/build.zig");
+const zgui = @import("../libs/zgui/build.zig");
+const zgpu = @import("../libs/zgpu/build.zig");
+const ztracy = @import("../libs/ztracy/build.zig");
+const zphysics = @import("../libs/zphysics/build.zig");
+const zaudio = @import("../libs/zaudio/build.zig");
+const zflecs = @import("../libs/zflecs/build.zig");
+
+pub var zmath_pkg: zmath.Package = undefined;
+pub var znoise_pkg: znoise.Package = undefined;
+pub var zopengl_pkg: zopengl.Package = undefined;
+pub var zsdl_pkg: zsdl.Package = undefined;
+pub var zpool_pkg: zpool.Package = undefined;
+pub var zmesh_pkg: zmesh.Package = undefined;
+pub var zglfw_pkg: zglfw.Package = undefined;
+pub var zstbi_pkg: zstbi.Package = undefined;
+pub var zbullet_pkg: zbullet.Package = undefined;
+pub var zgui_pkg: zgui.Package = undefined;
+pub var zgpu_pkg: zgpu.Package = undefined;
+pub var ztracy_pkg: ztracy.Package = undefined;
+pub var zphysics_pkg: zphysics.Package = undefined;
+pub var zaudio_pkg: zaudio.Package = undefined;
+pub var zflecs_pkg: zflecs.Package = undefined;
+
+pub var zwin32_pkg: zwin32.Package = undefined;
+pub var zd3d12_pkg: zd3d12.Package = undefined;
+pub var zpix_pkg: zpix.Package = undefined;
+pub var zxaudio2_pkg: zxaudio2.Package = undefined;
+pub var common_pkg: common.Package = undefined;
+pub var common_d2d_pkg: common.Package = undefined;
+pub var zd3d12_d2d_pkg: zd3d12.Package = undefined;
+
+fn packagesWindowsLinux(b: *std.Build, options: Options) void {
+    const target = options.target;
+    const optimize = options.optimize;
+
+    zwin32_pkg = zwin32.package(b, target, optimize, .{});
+    zd3d12_pkg = zd3d12.package(b, target, optimize, .{
+        .options = .{
+            .enable_debug_layer = options.zd3d12_enable_debug_layer,
+            .enable_gbv = options.zd3d12_enable_gbv,
+            .upload_heap_capacity = 32 * 1024 * 1024,
+        },
+        .deps = .{ .zwin32 = zwin32_pkg.zwin32 },
+    });
+    zpix_pkg = zpix.package(b, target, optimize, .{
+        .options = .{ .enable = options.zpix_enable },
+        .deps = .{ .zwin32 = zwin32_pkg.zwin32 },
+    });
+    common_pkg = common.package(b, target, optimize, .{
+        .deps = .{ .zwin32 = zwin32_pkg.zwin32, .zd3d12 = zd3d12_pkg.zd3d12 },
+    });
+}
+
+fn packagesCrossPlatform(b: *std.Build, options: Options) void {
+    const target = options.target;
+    const optimize = options.optimize;
+
+    zopengl_pkg = zopengl.package(b, target, optimize, .{});
+    zmath_pkg = zmath.package(b, target, optimize, .{});
+    zpool_pkg = zpool.package(b, target, optimize, .{});
+    zglfw_pkg = zglfw.package(b, target, optimize, .{});
+    zsdl_pkg = zsdl.package(b, target, optimize, .{});
+    zmesh_pkg = zmesh.package(b, target, optimize, .{});
+    znoise_pkg = znoise.package(b, target, optimize, .{});
+    zstbi_pkg = zstbi.package(b, target, optimize, .{});
+    zbullet_pkg = zbullet.package(b, target, optimize, .{});
+    zgui_pkg = zgui.package(b, target, optimize, .{
+        .options = .{ .backend = .glfw_wgpu },
+    });
+    zgpu_pkg = zgpu.package(b, target, optimize, .{
+        .options = .{ .uniforms_buffer_size = 4 * 1024 * 1024 },
+        .deps = .{ .zpool = zpool_pkg.zpool, .zglfw = zglfw_pkg.zglfw },
+    });
+    ztracy_pkg = ztracy.package(b, target, optimize, .{
+        .options = .{
+            .enable_ztracy = !target.isDarwin(), // TODO: ztracy fails to compile on macOS.
+            .enable_fibers = !target.isDarwin(),
+        },
+    });
+    zphysics_pkg = zphysics.package(b, target, optimize, .{});
+    zaudio_pkg = zaudio.package(b, target, optimize, .{});
+    zflecs_pkg = zflecs.package(b, target, optimize, .{});
+}
+
+fn packagesWindows(b: *std.Build, options: Options) void {
+    const target = options.target;
+    const optimize = options.optimize;
+
+    zd3d12_d2d_pkg = zd3d12.package(b, target, optimize, .{
+        .options = .{
+            .enable_debug_layer = options.zd3d12_enable_debug_layer,
+            .enable_gbv = options.zd3d12_enable_gbv,
+            .enable_d2d = true,
+        },
+        .deps = .{ .zwin32 = zwin32_pkg.zwin32 },
+    });
+    common_d2d_pkg = common.package(b, target, optimize, .{
+        .deps = .{ .zwin32 = zwin32_pkg.zwin32, .zd3d12 = zd3d12_d2d_pkg.zd3d12 },
+    });
+    zxaudio2_pkg = zxaudio2.package(b, target, optimize, .{
+        .options = .{ .enable_debug_layer = options.zd3d12_enable_debug_layer },
+        .deps = .{ .zwin32 = zwin32_pkg.zwin32 },
+    });
+}

--- a/samples/bullet_physics_test_wgpu/build.zig
+++ b/samples/bullet_physics_test_wgpu/build.zig
@@ -1,24 +1,24 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 
-const demo_name = "bullet_physics_test_wgpu";
-const content_dir = demo_name ++ "_content/";
+pub const name = "bullet_physics_test_wgpu";
+const content_dir = name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = demo_name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .name = name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
-    const zbullet_pkg = @import("../../build.zig").zbullet_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
+    const zbullet_pkg = @import("../build.zig").zbullet_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/directml_convolution_test/build.zig
+++ b/samples/directml_convolution_test/build.zig
@@ -1,19 +1,21 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "directml_convolution_test_content/";
+
+pub const name = "directml_convultion_test";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "directml_convolution_test",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/directml_convolution_test.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true, .directml = true });
     common_pkg.link(exe);

--- a/samples/gamepad_wgpu/build.zig
+++ b/samples/gamepad_wgpu/build.zig
@@ -1,22 +1,22 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 
-const demo_name = "gamepad_wgpu";
-const content_dir = demo_name ++ "_content/";
+pub const name = "gamepad_wgpu";
+const content_dir = name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = demo_name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .name = name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/gui_test_wgpu/build.zig
+++ b/samples/gui_test_wgpu/build.zig
@@ -1,23 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 
-const demo_name = "gui_test_wgpu";
-const content_dir = demo_name ++ "_content/";
+pub const name = "gui_test_wgpu";
+const content_dir = name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = demo_name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .name = name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zstbi_pkg = @import("../../build.zig").zstbi_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zstbi_pkg = @import("../build.zig").zstbi_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/instanced_pills_wgpu/build.zig
+++ b/samples/instanced_pills_wgpu/build.zig
@@ -1,23 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 
-const demo_name = "instanced_pills_wgpu";
+pub const name = "instanced_pills_wgpu";
 const demo_filename = "instanced_pills_wgpu";
-const content_dir = demo_name ++ "_content/";
+const content_dir = name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = demo_name,
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_filename ++ ".zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/layers_wgpu/build.zig
+++ b/samples/layers_wgpu/build.zig
@@ -1,22 +1,22 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 
-const demo_name = "layers_wgpu";
-const content_dir = demo_name ++ "_content/";
+pub const name = "layers_wgpu";
+const content_dir = name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = demo_name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .name = name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/mesh_shader_test/build.zig
+++ b/samples/mesh_shader_test/build.zig
@@ -1,20 +1,22 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "mesh_shader_test_content/";
+
+pub const name = "mesh_shader_test";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "mesh_shader_test",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/mesh_shader_test.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     zmesh_pkg.link(exe);

--- a/samples/minimal_d3d12/build.zig
+++ b/samples/minimal_d3d12/build.zig
@@ -1,16 +1,18 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
+
+pub const name = "minimal_d3d12";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "minimal_d3d12",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/minimal_d3d12.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
 

--- a/samples/minimal_glfw_gl/build.zig
+++ b/samples/minimal_glfw_gl/build.zig
@@ -1,17 +1,19 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
+
+pub const name = "minimal_glfw_gl";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "minimal_glfw_gl",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/minimal_glfw_gl.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zopengl_pkg = @import("../../build.zig").zopengl_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zopengl_pkg = @import("../build.zig").zopengl_pkg;
 
     zglfw_pkg.link(exe);
     zopengl_pkg.link(exe);

--- a/samples/minimal_sdl_gl/build.zig
+++ b/samples/minimal_sdl_gl/build.zig
@@ -1,17 +1,19 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
+
+pub const name = "minimal_sdl_gl";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "minimal_sdl_gl",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/minimal_sdl_gl.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zsdl_pkg = @import("../../build.zig").zsdl_pkg;
-    const zopengl_pkg = @import("../../build.zig").zopengl_pkg;
+    const zsdl_pkg = @import("../build.zig").zsdl_pkg;
+    const zopengl_pkg = @import("../build.zig").zopengl_pkg;
 
     zsdl_pkg.link(exe);
     zopengl_pkg.link(exe);

--- a/samples/minimal_zgpu_zgui/build.zig
+++ b/samples/minimal_zgpu_zgui/build.zig
@@ -1,21 +1,21 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 
-const demo_name = "minimal_zgpu_zgui";
-const content_dir = demo_name ++ "_content/";
+pub const name = "minimal_zgpu_zgui";
+const content_dir = name ++ "_content/";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = demo_name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .name = name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/monolith/build.zig
+++ b/samples/monolith/build.zig
@@ -1,21 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "monolith_content/";
+
+pub const name = "monolith";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "monolith",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/monolith.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
 
     const zphysics_pkg = @import("../../libs/zphysics/build.zig").package(b, options.target, options.optimize, .{
         .options = .{

--- a/samples/physically_based_rendering_wgpu/build.zig
+++ b/samples/physically_based_rendering_wgpu/build.zig
@@ -1,22 +1,24 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "physically_based_rendering_wgpu_content/";
+
+pub const name = "physically_based_rendering_wgpu";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "physically_based_rendering_wgpu",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/physically_based_rendering_wgpu.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zstbi_pkg = @import("../../build.zig").zstbi_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zstbi_pkg = @import("../build.zig").zstbi_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/physics_test_wgpu/build.zig
+++ b/samples/physics_test_wgpu/build.zig
@@ -1,22 +1,24 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "physics_test_wgpu_content/";
+
+pub const name = "physics_test_wgpu";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "physics_test_wgpu",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/physics_test_wgpu.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
-    const zphysics_pkg = @import("../../build.zig").zphysics_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
+    const zphysics_pkg = @import("../build.zig").zphysics_pkg;
 
     zmath_pkg.link(exe);
     zgui_pkg.link(exe);

--- a/samples/procedural_mesh_wgpu/build.zig
+++ b/samples/procedural_mesh_wgpu/build.zig
@@ -1,23 +1,25 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "procedural_mesh_wgpu_content/";
+
+pub const name = "procedural_mesh_wgpu";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "procedural_mesh_wgpu",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/procedural_mesh_wgpu.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
-    const ztracy_pkg = @import("../../build.zig").ztracy_pkg;
-    const znoise_pkg = @import("../../build.zig").znoise_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
+    const ztracy_pkg = @import("../build.zig").ztracy_pkg;
+    const znoise_pkg = @import("../build.zig").znoise_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/rasterization/build.zig
+++ b/samples/rasterization/build.zig
@@ -1,21 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "rasterization_content/";
+
+pub const name = "rasterization";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "rasterization",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/rasterization.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zmesh_pkg = @import("../build.zig").zmesh_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     zmesh_pkg.link(exe);

--- a/samples/simple_raytracer/build.zig
+++ b/samples/simple_raytracer/build.zig
@@ -1,20 +1,22 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "simple_raytracer_content/";
+
+pub const name = "simple_raytracer";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "simple_raytracer",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/simple_raytracer.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
-    const zpix_pkg = @import("../../build.zig").zpix_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
+    const zpix_pkg = @import("../build.zig").zpix_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     common_pkg.link(exe);

--- a/samples/textured_quad/build.zig
+++ b/samples/textured_quad/build.zig
@@ -1,19 +1,21 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "textured_quad_content/";
+
+pub const name = "textured_quad";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "textured_quad",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/textured_quad.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     common_pkg.link(exe);

--- a/samples/textured_quad_wgpu/build.zig
+++ b/samples/textured_quad_wgpu/build.zig
@@ -1,21 +1,23 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "textured_quad_wgpu_content/";
+
+pub const name = "textured_quad_wgpu";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "textured_quad_wgpu",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/textured_quad_wgpu.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
-    const zstbi_pkg = @import("../../build.zig").zstbi_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
+    const zstbi_pkg = @import("../build.zig").zstbi_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/triangle/build.zig
+++ b/samples/triangle/build.zig
@@ -1,19 +1,21 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "triangle_content/";
+
+pub const name = "triangle";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "triangle",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/triangle.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
-    const common_pkg = @import("../../build.zig").common_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_pkg = @import("../build.zig").zd3d12_pkg;
+    const common_pkg = @import("../build.zig").common_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     zd3d12_pkg.link(exe);

--- a/samples/triangle_wgpu/build.zig
+++ b/samples/triangle_wgpu/build.zig
@@ -1,20 +1,22 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
 const content_dir = "triangle_wgpu_content/";
+
+pub const name = "triangle_wgpu";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "triangle_wgpu",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/triangle_wgpu.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zgui_pkg = @import("../../build.zig").zgui_pkg;
-    const zmath_pkg = @import("../../build.zig").zmath_pkg;
-    const zgpu_pkg = @import("../../build.zig").zgpu_pkg;
-    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
+    const zgui_pkg = @import("../build.zig").zgui_pkg;
+    const zmath_pkg = @import("../build.zig").zmath_pkg;
+    const zgpu_pkg = @import("../build.zig").zgpu_pkg;
+    const zglfw_pkg = @import("../build.zig").zglfw_pkg;
 
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);

--- a/samples/vector_graphics_test/build.zig
+++ b/samples/vector_graphics_test/build.zig
@@ -1,18 +1,20 @@
 const std = @import("std");
 
-const Options = @import("../../build.zig").Options;
+const Options = @import("../build.zig").Options;
+
+pub const name = "vector_graphics_test";
 
 pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     const exe = b.addExecutable(.{
-        .name = "vector_graphics_test",
+        .name = name,
         .root_source_file = .{ .path = thisDir() ++ "/src/vector_graphics_test.zig" },
         .target = options.target,
         .optimize = options.optimize,
     });
 
-    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
-    const zd3d12_d2d_pkg = @import("../../build.zig").zd3d12_d2d_pkg;
-    const common_d2d_pkg = @import("../../build.zig").common_d2d_pkg;
+    const zwin32_pkg = @import("../build.zig").zwin32_pkg;
+    const zd3d12_d2d_pkg = @import("../build.zig").zd3d12_d2d_pkg;
+    const common_d2d_pkg = @import("../build.zig").common_d2d_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
     common_d2d_pkg.link(exe);


### PR DESCRIPTION
Changes:
* Separation of samples, experiments, tests and benchmarks build routines and options (*not sure about this, just experimenting*)
* Simplified samples build code

TODO:
* Refactor and move `makeDxc` from each sample to `zd3d12` lib
* Move common shader compilation steps from each sample to `common` lib
* Consider making samples buildable standalone
* Consider reverting samples package defs back to top-level build.zig