### PR TITLE
Enable having zmath as a dependency

### DIFF
--- a/libs/zmath/build.zig
+++ b/libs/zmath/build.zig
@@ -32,7 +32,7 @@ pub fn package(
 
     const zmath_options = step.createModule();
 
-    const zmath = b.createModule(.{
+    const zmath = b.addModule("zmath", .{
         .source_file = .{ .path = thisDir() ++ "/src/main.zig" },
         .dependencies = &.{
             .{ .name = "zmath_options", .module = zmath_options },
@@ -49,6 +49,10 @@ pub fn package(
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+
+    _ = package(b, target, optimize, .{ .options = .{
+        .enable_cross_platform_determinism = b.option(bool, "enable_cross_platform_determinism", "Whether to enable cross-platform determinism.") orelse true,
+    } });
 
     const test_step = b.step("test", "Run zmath tests");
     test_step.dependOn(runTests(b, optimize, target));

--- a/libs/zmath/build.zig.zon
+++ b/libs/zmath/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "zmath",
+    .version = "0.9.6",
+    .paths = .{""},
+}


### PR DESCRIPTION
This aims to be a first step / PoC in enabling use of the libs in this repo as individual dependencies.
This justs exposes the zmath package so that it can added as a dependency in a `build.zig` file with:
```zig
    b.dependency("zmath", .{}); // .{ .enable_cross_platform_determinism = false } or .{} which defaults to .enable_cross_platform_determinism = true
    exe.addModule("zmath", zmath.module("zmath"));
```
If this is deemed fine, this can be applied to others libs later on.


No other build file has been touched (namely samples), guess it would be better to do it in one fell swoop once all libs are available as dependencies.