### PR TITLE
Fix zig breaking change: Rename 'fabs' to 'abs'

### DIFF
--- a/libs/zmath/src/zmath.zig
+++ b/libs/zmath/src/zmath.zig
@@ -1347,7 +1347,7 @@ pub inline fn sqrt(v: anytype) @TypeOf(v) {
 }
 
 pub inline fn abs(v: anytype) @TypeOf(v) {
-    return @fabs(v); // load, andps
+    return @abs(v); // load, andps
 }
 
 pub inline fn select(mask: anytype, v0: anytype, v1: anytype) @TypeOf(v0, v1) {
@@ -3622,7 +3622,7 @@ test "zmath.sincos32" {
 }
 
 fn asin32(v: f32) f32 {
-    const x = @fabs(v);
+    const x = @abs(v);
     var omx = 1.0 - x;
     if (omx < 0.0) {
         omx = 0.0;
@@ -3676,7 +3676,7 @@ test "zmath.asin32" {
 }
 
 fn acos32(v: f32) f32 {
-    const x = @fabs(v);
+    const x = @abs(v);
     var omx = 1.0 - x;
     if (omx < 0.0) {
         omx = 0.0;
@@ -3731,7 +3731,7 @@ test "zmath.acos32" {
 
 pub fn modAngle32(in_angle: f32) f32 {
     const angle = in_angle + math.pi;
-    var temp: f32 = @fabs(angle);
+    var temp: f32 = @abs(angle);
     temp = temp - (2.0 * math.pi * @as(f32, @floatFromInt(@as(i32, @intFromFloat(temp / math.pi)))));
     temp = temp - math.pi;
     if (angle < 0.0) {


### PR DESCRIPTION
See https://github.com/ziglang/zig/commit/6a29646a553a93fc6a4cbf0fee5fa5362483c326

After this commit, 4 zmath tests will fail. 