### PR TITLE
zmath: fix getting started in README.md

### DIFF
--- a/libs/zmath/README.md
+++ b/libs/zmath/README.md
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    zmath_pkg = zmath.package(b, target, optimize, .{
+    const zmath_pkg = zmath.package(b, target, optimize, .{
         .options = .{ .enable_cross_platform_determinism = true },
     });
 


### PR DESCRIPTION
a8db2f6e0bc2482b2522a5b7405b60d65f2b5e77 inadvertently removed `const` which causes
> error: use of undeclared identifier 'zmath_pkg'`
> &nbsp;&nbsp;&nbsp;&nbsp;zmath_pkg = zmath.package(b, target, optimize, .{
> &nbsp;&nbsp;&nbsp;&nbsp;^~~~~~~~~