### PR TITLE
zsdl: Vulkan support for SDL3, corrected window flag bitfield struct for both SDL3 and SDL2

### DIFF
--- a/libs/zsdl/src/sdl2.zig
+++ b/libs/zsdl/src/sdl2.zig
@@ -165,16 +165,10 @@ pub const Window = opaque {
         tooltip: bool = false,
         popup_menu: bool = false,
         keyboard_grabbed: bool = false,
-
-        __unused21: bool = false,
-        __unused22: bool = false,
-        __unused23: bool = false,
-        __unused24: bool = false,
-
-        vulkan: bool = false,
+        __unused21: u7 = 0,
+        vulkan: bool = false, // 0x10000000
         metal: bool = false,
-
-        __unused: u5 = 0,
+        __unused30: u2 = 0,
 
         pub const fullscreen_desktop: Flags = .{ .fullscreen = true, ._desktop = true };
         pub const input_grabbed: Flags = .{ .mouse_grabbed = true };

--- a/libs/zsdl/src/sdl3.zig
+++ b/libs/zsdl/src/sdl3.zig
@@ -161,10 +161,10 @@ pub const Window = opaque {
         tooltip: bool = false,
         popup_menu: bool = false,
         keyboard_grabbed: bool = false,
-        __unused21: u4 = 0,
-        vulkan: bool = false,
+        __unused21: u7 = 0,
+        vulkan: bool = false, // 0x10000000
         metal: bool = false,
-        __unused27: u5 = 0,
+        __unused30: u2 = 0,
     };
 
     pub const pos_undefined = posUndefinedDisplay(0);
@@ -1058,6 +1058,36 @@ extern fn SDL_GetWindowWMInfo(window: *Window, info: *SysWMInfo) c_int;
 // Vulkan Support
 //
 //--------------------------------------------------------------------------------------------------
+pub const vk = struct {
+
+    pub const FunctionPointer = ?*const anyopaque;
+    pub const Instance = enum(usize) { null_handle = 0, _ };
+
+    pub fn loadLibrary(path: ?[*:0]const u8) Error!void {
+        if (SDL_Vulkan_LoadLibrary(path) < 0) return makeError();
+    }
+    extern fn SDL_Vulkan_LoadLibrary(path: ?[*]const u8) i32;
+
+    pub fn getVkGetInstanceProcAddr() FunctionPointer {
+        return SDL_Vulkan_GetVkGetInstanceProcAddr();
+    }
+    extern fn SDL_Vulkan_GetVkGetInstanceProcAddr() FunctionPointer;
+
+    pub fn unloadLibrary() void {
+        SDL_Vulkan_UnloadLibrary();
+    }
+    extern fn SDL_Vulkan_UnloadLibrary() void;
+
+    pub fn getInstanceExtensions(count: *i32, maybe_names: ?[*][*:0]u8) bool {
+        return SDL_Vulkan_GetInstanceExtensions(count, maybe_names);
+    }
+    extern fn SDL_Vulkan_GetInstanceExtensions(count: *i32, names: ?[*][*]u8) bool;
+
+    pub fn createSurface(window: *Window, instance: Instance, surface: *anyopaque) bool {
+        return SDL_Vulkan_CreateSurface(window, instance, surface);
+    }
+    extern fn SDL_Vulkan_CreateSurface(window: *Window, instance: Instance, surface: *anyopaque) bool;
+};
 
 //--------------------------------------------------------------------------------------------------
 //


### PR DESCRIPTION
The vulkan methods implemented for sdl3 may also work for sdl2, but I didn't test that, so I didn't PR it.

The struct that serves as a bitfield that mimics SDL's window flags enum was 3 bits off for the vulkan and metal flags. After moving those flags 3 bits further toward the big end, my vulkan tests worked, and the math works out.

I suspect nobody had actually tried creating a vulkan or metal surface with zsdl yet, which is why this hadn't yet been fixed.