### PR TITLE
zphysics: Implemented Shape.getCenterOfMass

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -1728,6 +1728,12 @@ JPC_Shape_SetUserData(JPC_Shape *in_shape, uint64_t in_user_data)
     return toJph(in_shape)->SetUserData(in_user_data);
 }
 //--------------------------------------------------------------------------------------------------
+JPC_API void
+JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3])
+{
+    storeRVec3(out_position, toJph(in_shape)->GetCenterOfMass());
+}
+//--------------------------------------------------------------------------------------------------
 //
 // JPC_BodyInterface
 //

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -1513,6 +1513,9 @@ JPC_Shape_GetUserData(const JPC_Shape *in_shape);
 
 JPC_API void
 JPC_Shape_SetUserData(JPC_Shape *in_shape, uint64_t in_user_data);
+
+JPC_API void
+JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3]);
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_BodyInterface

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -3179,6 +3179,12 @@ pub const Shape = opaque {
             pub fn setUserData(shape: *T, user_data: u64) void {
                 return c.JPC_Shape_SetUserData(@as(*c.JPC_Shape, @ptrCast(shape)), user_data);
             }
+
+            pub fn getCenterOfMass(shape: *const T) [3]Real {
+                var center: [3]Real = undefined;
+                c.JPC_Shape_GetCenterOfMass(@as(*const c.JPC_Shape, @ptrCast(shape)), &center);
+                return center;
+            }
         };
     }
 };


### PR DESCRIPTION
Which is useful for getting the translation from Jolt's calculated center of mass frame back to the frame you used when creating the shape, if those are different. In the case of convex hulls, for example, they're often different.