### PR TITLE
make zglfw consumable by package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pub fn build(b: *std.Build) void {
 | **[zmesh](libs/zmesh)**       | 0.9.0          | Loading, generating, processing and optimizing triangle meshes                                                             |
 | **[ztracy](libs/ztracy)**     | 0.9.0          | Support for CPU profiling with [Tracy](https://github.com/wolfpld/tracy)                                                   |
 | **[zpool](libs/zpool)**       | 0.9.0          | Generic pool & handle implementation                                                                                       |
-| **[zglfw](libs/zglfw)**       | 0.6.0          | Minimalistic [GLFW](https://github.com/glfw/glfw) bindings with no translate-c dependency                                  |
+| **[zglfw](libs/zglfw)**       | 0.7.0          | Minimalistic [GLFW](https://github.com/glfw/glfw) bindings with no translate-c dependency                                  |
 | **[znoise](libs/znoise)**     | 0.1.0          | Zig bindings for [FastNoiseLite](https://github.com/Auburn/FastNoiseLite)                                                  |
 | **[zjobs](libs/zjobs)**       | 0.1.0          | Generic job queue implementation                                                                                           |
 | **[zbullet](libs/zbullet)**   | 0.2.0          | Zig bindings and C API for [Bullet physics library](https://github.com/bulletphysics/bullet3)                              |

--- a/libs/zglfw/build.zig
+++ b/libs/zglfw/build.zig
@@ -49,13 +49,13 @@ pub fn package(
     const step = b.addOptions();
     step.addOption(bool, "shared", args.options.shared);
 
-    const zglfw = b.createModule(.{
+    const zglfw = b.addModule("zglfw", .{
         .source_file = .{ .path = thisDir() ++ "/src/zglfw.zig" },
     });
 
     const zglfw_c_cpp = if (args.options.shared) blk: {
         const lib = b.addSharedLibrary(.{
-            .name = "zglfw",
+            .name = "libglfw",
             .target = target,
             .optimize = optimize,
         });
@@ -66,7 +66,7 @@ pub fn package(
 
         break :blk lib;
     } else b.addStaticLibrary(.{
-        .name = "zglfw",
+        .name = "libglfw",
         .target = target,
         .optimize = optimize,
     });
@@ -184,6 +184,9 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run zglfw tests");
     test_step.dependOn(runTests(b, optimize, target));
+
+    const pkg = package(b, target, optimize, .{});
+    b.installArtifact(pkg.zglfw_c_cpp);
 }
 
 pub fn runTests(

--- a/libs/zglfw/build.zig.zon
+++ b/libs/zglfw/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "zglfw",
+    .version = "0.7.0",
+    .paths = .{""},
+}


### PR DESCRIPTION
### Example usage

<details>
<summary>build.zig.zon</summary>

```zig
.{
    .name = "example",
    .version = "0.1.0",
    .paths = .{""},
    .dependencies = .{
        .zglfw = .{
            .path = "./libs/zglfw",  
        },
    },
}
```

</details>

<details>
<summary>build.zig</summary>

 ```zig
pub fn build(b: *std.Build) !void {
    ...

    const zglfw = b.dependency("zglfw", .{
        .target = target,
        .optimize = optimize,
    });

    const exe = b.addExecutable(.{
        .name = name,
        .root_source_file = .{ .path = "src/example.zig" },
        .target = target,
        .optimize = optimize,
    });

    exe.linkLibrary(zglfw.artifact("libglfw"));
    exe.addModule("zglfw", zglfw.module("zglfw"));

    ...
```

</details>

zglfw can then be imported and used as usual

### Note
system-sdk is still currently required to be colocated with zglfw. Hence, this only allows zglfw to be consumed as a dependency by path and not by url. Further work is required to make system-sdk a dependency of zglfw.