### PR TITLE
Improve zgui README

### DIFF
--- a/libs/zgui/README.md
+++ b/libs/zgui/README.md
@@ -15,6 +15,17 @@ Copy `zgui` folder to a `libs` subdirectory of the root of your project.
 
 To get glfw/wgpu rendering backend working also copy `zgpu`, `zglfw`, `zpool` and `system-sdk` folders (see [zgpu](https://github.com/michal-z/zig-gamedev/tree/main/libs/zgpu) for the details). Alternatively, you can provide your own rendering backend, see: [backend_glfw_wgpu.zig](src/backend_glfw_wgpu.zig) for an example.
 
+Next, copy [build.zig.zon](build.zig.zon) from the root of the `zig-gamedev` project to the root of your project and adjust `name` and `version` accordingly:
+
+``` zig
+.{
+    .name = "<your_project_name>",
+    .version = "<your_project_version",
+    // leave the rest unchanged
+    ...
+}
+```
+
 Then in your `build.zig` add:
 ```zig
 const zgui = @import("libs/zgui/build.zig");


### PR DESCRIPTION
Add a missing step to the readme: describe how to copy and adjust the `build.zig.zon` file.

Closes #445 