### PR TITLE
Correct minor typos in `JoltPhysicsC.h`

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -2389,13 +2389,13 @@ JPC_Body_GetAngularVelocity(const JPC_Body *in_body, float out_angular_velocity[
 }
 //--------------------------------------------------------------------------------------------------
 JPC_API void
-JPC_Body_SetAnglularVelocity(JPC_Body *in_body, const float in_angular_velocity[3])
+JPC_Body_SetAngularVelocity(JPC_Body *in_body, const float in_angular_velocity[3])
 {
     toJph(in_body)->SetAngularVelocity(loadVec3(in_angular_velocity));
 }
 //--------------------------------------------------------------------------------------------------
 JPC_API void
-JPC_Body_SetAnglularVelocityClamped(JPC_Body *in_body, const float in_angular_velocity[3])
+JPC_Body_SetAngularVelocityClamped(JPC_Body *in_body, const float in_angular_velocity[3])
 {
     toJph(in_body)->SetAngularVelocityClamped(loadVec3(in_angular_velocity));
 }

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -339,7 +339,7 @@ typedef struct JPC_MotionProperties
     float              torque[3];
     float              inv_mass;
     float              linear_damping;
-    float              angular_daming;
+    float              angular_damping;
     float              max_linear_velocity;
     float              max_angular_velocity;
     float              gravity_factor;
@@ -1870,10 +1870,10 @@ JPC_API void
 JPC_Body_GetAngularVelocity(const JPC_Body *in_body, float out_angular_velocity[3]);
 
 JPC_API void
-JPC_Body_SetAnglularVelocity(JPC_Body *in_body, const float in_angular_velocity[3]);
+JPC_Body_SetAngularVelocity(JPC_Body *in_body, const float in_angular_velocity[3]);
 
 JPC_API void
-JPC_Body_SetAnglularVelocityClamped(JPC_Body *in_body, const float in_angular_velocity[3]);
+JPC_Body_SetAngularVelocityClamped(JPC_Body *in_body, const float in_angular_velocity[3]);
 
 JPC_API void
 JPC_Body_GetPointVelocityCOM(const JPC_Body *in_body,

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -332,7 +332,7 @@ typedef struct JPC_MotionProperties
 {
     alignas(16) float  linear_velocity[4]; // 4th element is ignored
     alignas(16) float  angular_velocity[4]; // 4th element is ignored
-    alignas(16) float  inv_inertia_diagnonal[4]; // 4th element is ignored
+    alignas(16) float  inv_inertia_diagonal[4]; // 4th element is ignored
     alignas(16) float  inertia_rotation[4];
 
     float              force[3];

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -2415,7 +2415,7 @@ pub const CharacterVirtual = opaque {
 pub const MotionProperties = extern struct {
     linear_velocity: [4]f32 align(16), // 4th element is ignored
     angular_velocity: [4]f32 align(16), // 4th element is ignored
-    inv_inertia_diagnonal: [4]f32 align(16),
+    inv_inertia_diagonal: [4]f32 align(16),
     inertia_rotation: [4]f32 align(16),
 
     force: [3]f32,
@@ -2458,10 +2458,10 @@ pub const MotionProperties = extern struct {
         return velocity;
     }
     pub fn setAngularVelocity(motion: *MotionProperties, velocity: [3]f32) void {
-        c.JPC_MotionProperties_SetAnglularVelocity(@as(*c.JPC_MotionProperties, @ptrCast(motion)), &velocity);
+        c.JPC_MotionProperties_SetAngularVelocity(@as(*c.JPC_MotionProperties, @ptrCast(motion)), &velocity);
     }
     pub fn setAngularVelocityClamped(motion: *MotionProperties, velocity: [3]f32) void {
-        c.JPC_MotionProperties_SetAnglularVelocityClamped(@as(*c.JPC_MotionProperties, @ptrCast(motion)), &velocity);
+        c.JPC_MotionProperties_SetAngularVelocityClamped(@as(*c.JPC_MotionProperties, @ptrCast(motion)), &velocity);
     }
 
     /// `point` is relative to the center of mass (com)


### PR DESCRIPTION
This PR fixes a few minor spellings in `JoltPhysicsC.H`