### PR TITLE
Fix building zgui as a shared lib on macOS

### DIFF
--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -63,6 +63,10 @@ pub fn package(
             lib.defineCMacro("ZGUI_API", "__declspec(dllexport)");
         }
 
+        if (target.isDarwin()) {
+            lib.linker_allow_shlib_undefined = true;
+        }
+
         break :blk lib;
     } else b.addStaticLibrary(.{
         .name = "zgui",


### PR DESCRIPTION
Fixes #453

Enable linker_allow_shlib_undefined if zgui is built as a shared library on macos. This resolves the `undefined reference to symbol` errors you would get before.

