### PR TITLE
Update zgui `build.zig` to new API

### DIFF
--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -20,17 +20,17 @@ pub const Package = struct {
     options: Options,
     zgui: *std.Build.Module,
     zgui_options: *std.Build.Module,
-    zgui_c_cpp: *std.Build.CompileStep,
-
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
+    zgui_c_cpp: *std.Build.Step.Compile,
+    
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
         exe.linkLibrary(pkg.zgui_c_cpp);
-        exe.addModule("zgui", pkg.zgui);
+        exe.root_module.addImport("zgui", pkg.zgui);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    target: std.zig.CrossTarget,
+    target: std.Build.ResolvedTarget,
     optimize: std.builtin.Mode,
     args: struct {
         options: Options,
@@ -39,80 +39,76 @@ pub fn package(
     const step = b.addOptions();
     step.addOption(Backend, "backend", args.options.backend);
     step.addOption(bool, "shared", args.options.shared);
-
+    
     const zgui_options = step.createModule();
-
+    
     const zgui = b.createModule(.{
-        .source_file = .{ .path = thisDir() ++ "/src/gui.zig" },
-        .dependencies = &.{
-            .{ .name = "zgui_options", .module = zgui_options },
-        },
+        .root_source_file = .{ .path = thisDir() ++ "/src/gui.zig" },
+                                .imports = &.{
+                                    .{ .name = "zgui_options", .module = zgui_options },
+                                },
     });
-
+    
     const zgui_c_cpp = if (args.options.shared) blk: {
         const lib = b.addSharedLibrary(.{
             .name = "zgui",
             .target = target,
             .optimize = optimize,
         });
-
+        
         b.installArtifact(lib);
-        if (target.isWindows()) {
+        if (target.result.os.tag == .windows) {
             lib.defineCMacro("IMGUI_API", "__declspec(dllexport)");
             lib.defineCMacro("IMPLOT_API", "__declspec(dllexport)");
             lib.defineCMacro("ZGUI_API", "__declspec(dllexport)");
         }
-
-        if (target.isDarwin()) {
-            lib.linker_allow_shlib_undefined = true;
-        }
-
+        
         break :blk lib;
     } else b.addStaticLibrary(.{
         .name = "zgui",
         .target = target,
         .optimize = optimize,
     });
-
+    
     zgui_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs" });
     zgui_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/imgui" });
-
-    const abi = (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target.abi;
+    
+    const abi = (std.zig.system.resolveTargetQuery(target.query) catch unreachable).abi;
     zgui_c_cpp.linkLibC();
     if (abi != .msvc)
         zgui_c_cpp.linkLibCpp();
-
+    
     const cflags = &.{"-fno-sanitize=undefined"};
-
+    
     zgui_c_cpp.addCSourceFile(.{
         .file = .{ .path = thisDir() ++ "/src/zgui.cpp" },
-        .flags = cflags,
+                              .flags = cflags,
     });
-
+    
     if (args.options.with_imgui) {
         zgui_c_cpp.addCSourceFiles(.{
             .files = &.{
                 thisDir() ++ "/libs/imgui/imgui.cpp",
-                thisDir() ++ "/libs/imgui/imgui_widgets.cpp",
-                thisDir() ++ "/libs/imgui/imgui_tables.cpp",
-                thisDir() ++ "/libs/imgui/imgui_draw.cpp",
-                thisDir() ++ "/libs/imgui/imgui_demo.cpp",
+                                   thisDir() ++ "/libs/imgui/imgui_widgets.cpp",
+                                   thisDir() ++ "/libs/imgui/imgui_tables.cpp",
+                                   thisDir() ++ "/libs/imgui/imgui_draw.cpp",
+                                   thisDir() ++ "/libs/imgui/imgui_demo.cpp",
             },
             .flags = cflags,
         });
     }
-
+    
     if (args.options.with_implot) {
         zgui_c_cpp.addCSourceFiles(.{
             .files = &.{
                 thisDir() ++ "/libs/imgui/implot_demo.cpp",
-                thisDir() ++ "/libs/imgui/implot.cpp",
-                thisDir() ++ "/libs/imgui/implot_items.cpp",
+                                   thisDir() ++ "/libs/imgui/implot.cpp",
+                                   thisDir() ++ "/libs/imgui/implot_items.cpp",
             },
             .flags = cflags,
         });
     }
-
+    
     switch (args.options.backend) {
         .glfw_wgpu => {
             zgui_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/../zglfw/libs/glfw/include" });
@@ -120,7 +116,7 @@ pub fn package(
             zgui_c_cpp.addCSourceFiles(.{
                 .files = &.{
                     thisDir() ++ "/libs/imgui/backends/imgui_impl_glfw.cpp",
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_wgpu.cpp",
+                                       thisDir() ++ "/libs/imgui/backends/imgui_impl_wgpu.cpp",
                 },
                 .flags = cflags,
             });
@@ -131,7 +127,7 @@ pub fn package(
             zgui_c_cpp.addCSourceFiles(.{
                 .files = &.{
                     thisDir() ++ "/libs/imgui/backends/imgui_impl_glfw.cpp",
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_opengl3.cpp",
+                                       thisDir() ++ "/libs/imgui/backends/imgui_impl_opengl3.cpp",
                 },
                 .flags = &(cflags.* ++ .{"-DIMGUI_IMPL_OPENGL_LOADER_CUSTOM"}),
             });
@@ -140,16 +136,16 @@ pub fn package(
             zgui_c_cpp.addCSourceFiles(.{
                 .files = &.{
                     thisDir() ++ "/libs/imgui/backends/imgui_impl_win32.cpp",
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_dx12.cpp",
+                                       thisDir() ++ "/libs/imgui/backends/imgui_impl_dx12.cpp",
                 },
                 .flags = cflags,
             });
-            zgui_c_cpp.linkSystemLibraryName("d3dcompiler_47");
-            zgui_c_cpp.linkSystemLibraryName("dwmapi");
+            zgui_c_cpp.root_module.linkSystemLibrary("d3dcompiler_47", .{});
+            zgui_c_cpp.root_module.linkSystemLibrary("dwmapi", .{});
         },
         .no_backend => {},
     }
-
+    
     return .{
         .options = args.options,
         .zgui = zgui,


### PR DESCRIPTION
The old API was deprecated and will be removed in zig 0.12
This PR changes the old API functions to new ones.

see: https://github.com/ziglang/zig/commit/142471fcc46070326526e3976f0150fe734df0b6

Verified that it builds on my machine with zig env:
```
 "version": "0.11.0",
 "target": "x86_64-linux.6.5...6.5-gnu.2.19"
```
and
```
 "version": "0.12.0-dev.2030+2ac315c24",
 "target": "x86_64-linux.6.5...6.5-gnu.2.38",
```